### PR TITLE
Defer Langfuse shutdown after agent_end and add tool metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Langfuse provides open-source observability for LLM applications. This extension
 - **REST fallback for self-hosted Langfuse**: Uses the Langfuse OpenTelemetry SDK first, then verifies that the trace is visible. If a self-hosted OTel ingestion pipeline accepts spans but does not materialize traces, the extension writes the run through Langfuse's REST ingestion API.
 - **Per-Request Generations**: Records a separate `generation` observation for every provider request, including the actual provider payload instead of only the original prompt.
 - **Final Message Capture**: Uses finalized assistant messages for generation and root outputs, so Langfuse shows what the user actually saw in Pi.
-- **Tool Observability**: Creates Langfuse `tool` observations for every tool call, including arguments, results, and error states.
+- **Tool Observability**: Creates Langfuse `tool` observations for every tool call, including arguments, results, error states, and payload/latency metrics.
 - **Parallel Tool Safety**: Correlates tool observations by `toolCallId`, avoiding result mix-ups when Pi runs tools concurrently.
 - **Session Correlation**: Groups traces from the same Pi session under a shared Langfuse session ID.
 - **Cost and Token Tracking**: Records usage and cost details on each generation when Pi/provider payloads expose them.
@@ -32,6 +32,7 @@ Langfuse provides open-source observability for LLM applications. This extension
 - The first generation in a tool-using run can show the assistant's tool-call message, the tool observation shows execution I/O, and the follow-up generation shows the final natural-language answer.
 - Tool failures are marked on the tool observation and reflected in trace-level scores, while later generations still preserve the tool error result in their input history.
 - Shutdown and interrupted runs flush pending telemetry and mark unfinished observations as cancelled/warning instead of silently losing the trace.
+- Agent-end runtime shutdown is deferred so Langfuse flushing does not block Pi's visible turn completion.
 
 ## Prerequisites
 
@@ -265,6 +266,9 @@ Trace (name: "pi-agent")
 | `output` | Tool result, shaped and truncated for readability |
 | `metadata.toolCallId` | Stable Pi tool call identifier |
 | `metadata.isError` | Whether the tool failed |
+| `metadata.durationMs` | Approximate tool runtime in milliseconds |
+| `metadata.inputBytes` | UTF-8 byte size of the shaped tool input payload |
+| `metadata.outputBytes` | UTF-8 byte size of the shaped tool output payload |
 | `level` | `ERROR` for failed tool calls, otherwise `DEFAULT` |
 
 ### Observation-Level Scores

--- a/index.ts
+++ b/index.ts
@@ -128,7 +128,11 @@ export default async function (pi: ExtensionAPI) {
 
   pi.on("agent_end", async (event) => {
     await finishAgentRun(event);
-    await shutdownRuntime();
+    setTimeout(() => {
+      shutdownRuntime().catch((error) => {
+        console.warn("📊 Langfuse: Deferred shutdown failed", error);
+      });
+    }, 0);
   });
 
   const handleSessionInterruption = (reason: string) => {

--- a/src/handlers/tool.ts
+++ b/src/handlers/tool.ts
@@ -7,6 +7,7 @@ import {
   shapePayload,
   extractTextContent,
   truncate,
+  estimatePayloadBytes,
 } from "../utils.js";
 import { MAX_TOOL_PAYLOAD_LENGTH } from "../constants.js";
 
@@ -22,27 +23,36 @@ export async function startToolObservation(event: Record<string, unknown>) {
 
   try {
     const toolName = getToolName(event);
+    const toolInput = getToolInput(event);
+    const shapedInput = shapePayload(toolInput, { maxString: MAX_TOOL_PAYLOAD_LENGTH });
+    const inputBytes = estimatePayloadBytes(shapedInput, MAX_TOOL_PAYLOAD_LENGTH);
     const parent = state.agentState.activeTurn ?? state.agentState.root;
     const tool = parent.startObservation
       ? parent.startObservation(
           toolName,
           {
-            input: shapePayload(getToolInput(event), { maxString: MAX_TOOL_PAYLOAD_LENGTH }),
-            metadata: { toolName, toolCallId },
+            input: shapedInput,
+            metadata: { toolName, toolCallId, inputBytes },
           },
           { asType: "tool" },
         )
       : (await getRuntime()).startObservation(
           toolName,
           {
-            input: shapePayload(getToolInput(event), { maxString: MAX_TOOL_PAYLOAD_LENGTH }),
-            metadata: { toolName, toolCallId },
+            input: shapedInput,
+            metadata: { toolName, toolCallId, inputBytes },
           },
           { asType: "tool" },
         );
 
     state.toolCallCount++;
-    state.agentState.activeTools.set(toolCallId, { observation: tool, toolName, ended: false });
+    state.agentState.activeTools.set(toolCallId, {
+      observation: tool,
+      toolName,
+      ended: false,
+      startedAt: Date.now(),
+      inputBytes,
+    });
   } catch (e) {
     console.warn("📊 Langfuse: Failed to start tool observation", e);
   }
@@ -73,15 +83,22 @@ export async function finishToolObservation(event: Record<string, unknown>) {
     event;
 
   try {
+    const shapedOutput = shapePayload(output, { maxString: MAX_TOOL_PAYLOAD_LENGTH });
+    const outputBytes = estimatePayloadBytes(shapedOutput, MAX_TOOL_PAYLOAD_LENGTH);
+    const durationMs = Math.max(0, Date.now() - activeTool.startedAt);
+
     activeTool.observation
       .update({
-        output: shapePayload(output, { maxString: MAX_TOOL_PAYLOAD_LENGTH }),
+        output: shapedOutput,
         level: isError ? "ERROR" : "DEFAULT",
         statusMessage: isError ? truncate(String(event.error ?? output), 1_000) : undefined,
         metadata: {
           toolName: activeTool.toolName,
           toolCallId,
           isError,
+          durationMs,
+          inputBytes: activeTool.inputBytes,
+          outputBytes,
         },
       })
       .end();

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,8 @@ export interface ToolState {
   observation: LangfuseObservation;
   toolName: string;
   ended: boolean;
+  startedAt: number;
+  inputBytes: number;
 }
 
 export interface AgentState {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -97,6 +97,10 @@ export function safeSerialize(value: unknown, maxLength = MAX_TOOL_PAYLOAD_LENGT
   }
 }
 
+export function estimatePayloadBytes(value: unknown, maxLength = MAX_TOOL_PAYLOAD_LENGTH): number {
+  return new TextEncoder().encode(safeSerialize(value, maxLength)).length;
+}
+
 export function extractTextContent(content: unknown, maxLength?: number): string | undefined {
   if (typeof content === "string") {
     return maxLength ? truncate(content, maxLength) : content;


### PR DESCRIPTION
## Summary

This PR makes two small tracing improvements:

- defer `shutdownRuntime()` after `agent_end` so Langfuse flushing does not add visible end-of-turn latency
- add extra tool observation metadata:
  - `durationMs`
  - `inputBytes`
  - `outputBytes`

## Details

### Deferred shutdown
`agent_end` currently waits for both run finalization and runtime shutdown. This keeps tracing correct, but can also make shutdown flushing part of the user-visible completion path.

This change keeps `finishAgentRun(event)` awaited, but defers `shutdownRuntime()` with `setTimeout(..., 0)`.

### Tool metrics
Tool observations already include input, output, and error state. This adds a few lightweight metrics to make traces easier to compare and debug:

- `durationMs`: approximate wall-clock runtime
- `inputBytes`: UTF-8 byte size of the shaped tool input
- `outputBytes`: UTF-8 byte size of the shaped tool output

## Notes

- `session_shutdown` behavior is unchanged
- byte counts are based on the shaped/truncated payload prepared for Langfuse
- README updated accordingly
