### PR TITLE
Add safe source metadata to Pi traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,53 @@ The package also includes a Langfuse CLI skill, so Langfuse data can be queried 
 /pi-langfuse-langfuse <your-query>
 ```
 
+## Source Metadata
+
+Local prototype note: source metadata support in this installed package is a local prototype patch. A durable solution should be shipped through an upstream PR, a fork, or a maintained package version so reinstalling the extension does not lose the behavior.
+
+For Git-backed runs, the extension attaches safe source metadata to traces:
+
+```json
+{
+  "source_type": "git-repo",
+  "repo_identity": "owner/repo",
+  "repo_owner": "owner",
+  "repo_name": "repo",
+  "repo_root_name": "repo",
+  "git_branch": "main",
+  "git_commit": "abc123",
+  "git_remote_host": "github.com",
+  "git_remote_path": "owner/repo",
+  "metadata_source": "git-detection"
+}
+```
+
+`repo_identity` is `owner/repo`. `repo_name` is the repo name only and must not contain a slash.
+
+A Git repo may optionally provide `.pi-langfuse.metadata.json`. Overrides are whitelist-only; unknown keys are ignored. Allowed keys are:
+
+```text
+repo_identity
+repo_owner
+repo_name
+source_type
+service_name
+project_slug
+environment
+observability_owner
+```
+
+Repo-local overrides are used only after the working directory is confirmed to be inside a usable Git repo. If Git detection fails for any reason, including a missing Git command, corrupted repo, or non-Git folder, the extension ignores repo-local identity files and emits only:
+
+```json
+{
+  "source_type": "non-git",
+  "metadata_source": "non-git"
+}
+```
+
+The extension must not upload raw absolute local paths, credentialed remotes, tokens, unknown override keys, or folder names for non-Git folders.
+
 ## Troubleshooting
 
 ### No traces appearing?

--- a/src/handlers/agent.ts
+++ b/src/handlers/agent.ts
@@ -4,6 +4,7 @@ import { ensureConfig } from "../config.js";
 import { shapePayload, truncate, extractFinalAssistant, extractAssistantOutput, getCapturePolicy } from "../utils.js";
 import { closeDanglingObservations } from "./tool.js";
 import { applyCapturePolicy } from "../capture-policy.js";
+import { collectSourceMetadata } from "../source-metadata.js";
 
 function stringMetadata(metadata: Record<string, unknown> | undefined): Record<string, string> | undefined {
   if (!metadata) {
@@ -67,11 +68,13 @@ export async function startAgentRun(event: Record<string, unknown>, ctx: any) {
       images: event.images,
       context: event.context ?? event.attachments,
     });
+    const sourceMetadata = collectSourceMetadata(cwd);
     const captured = applyCapturePolicy(
       {
         input: rawPromptInput,
         metadata: {
           cwd,
+          ...sourceMetadata,
           ...(state.currentModel ? { model: state.currentModel } : {}),
           ...(state.currentProvider ? { provider: state.currentProvider } : {}),
           sessionId: state.currentSessionId || undefined,
@@ -88,6 +91,7 @@ export async function startAgentRun(event: Record<string, unknown>, ctx: any) {
       activeGenerations: new Map(),
       generationOrder: [],
       activeTools: new Map(),
+      sourceMetadata,
       providerMetadataByRequest: new Map(),
     };
 
@@ -133,6 +137,7 @@ export async function finishAgentRun(event: Record<string, unknown> = {}) {
       output: rawOutput,
       metadata: {
         cwd: state.agentState.cwd,
+        ...(state.agentState.sourceMetadata ?? {}),
         completed: true,
         model: state.currentModel || undefined,
         provider: state.currentProvider || undefined,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -335,7 +335,8 @@ async function fallbackToRestIngestion(rt: LangfuseRuntime) {
   }
 
   const responseBody = response as { errors?: unknown[] } | undefined;
-  const errors = Array.isArray(responseBody?.errors) ? responseBody.errors : [];
+  const responseErrors = responseBody?.errors;
+  const errors = Array.isArray(responseErrors) ? responseErrors : [];
   if (errors.length > 0) {
     console.warn("📊 Langfuse: REST fallback ingestion reported errors", errors);
   } else {

--- a/src/source-metadata.ts
+++ b/src/source-metadata.ts
@@ -1,0 +1,160 @@
+import { existsSync, readFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+export type SourceMetadata = Record<string, string>;
+
+const OVERRIDE_KEYS = new Set([
+  "repo_identity",
+  "repo_owner",
+  "repo_name",
+  "source_type",
+  "service_name",
+  "project_slug",
+  "environment",
+  "observability_owner",
+]);
+
+function nonGitMetadata(): SourceMetadata {
+  return {
+    source_type: "non-git",
+    metadata_source: "non-git",
+  };
+}
+
+function runGit(cwd: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 2000,
+  }).trim();
+}
+
+function firstLine(value: string): string {
+  return value.split(/\r?\n/).map((line) => line.trim()).find(Boolean) ?? "";
+}
+
+export function sanitizeGitRemote(remoteUrl: string): Partial<Pick<SourceMetadata, "git_remote_host" | "git_remote_path">> {
+  const raw = firstLine(remoteUrl).replace(/\.git$/i, "");
+  if (!raw) {
+    return {};
+  }
+
+  try {
+    const parsed = new URL(raw);
+    const path = parsed.pathname.replace(/^\/+/, "").replace(/\.git$/i, "");
+    return parsed.hostname && path ? { git_remote_host: parsed.hostname, git_remote_path: path } : {};
+  } catch {
+    // Continue with scp-like SSH syntax, for example git@github.com:owner/repo.git.
+  }
+
+  const scpLike = raw.match(/^(?:[^@\s/:]+@)?([^:\s]+):(.+)$/);
+  if (scpLike) {
+    const host = scpLike[1];
+    const path = scpLike[2].replace(/^\/+/, "").replace(/\.git$/i, "");
+    return host && path && !path.includes("@") ? { git_remote_host: host, git_remote_path: path } : {};
+  }
+
+  return {};
+}
+
+function deriveIdentity(remotePath: string | undefined): Partial<Pick<SourceMetadata, "repo_identity" | "repo_owner" | "repo_name">> {
+  if (!remotePath) {
+    return {};
+  }
+  const parts = remotePath.split("/").filter(Boolean);
+  if (parts.length < 2) {
+    return {};
+  }
+  const repoName = parts[parts.length - 1];
+  const owner = parts[parts.length - 2];
+  if (!repoName || !owner || repoName.includes("/")) {
+    return {};
+  }
+  return {
+    repo_identity: `${owner}/${repoName}`,
+    repo_owner: owner,
+    repo_name: repoName,
+  };
+}
+
+function findRepoMetadataFile(cwd: string, gitRoot: string): string | undefined {
+  let current = cwd;
+  const root = gitRoot;
+  while (true) {
+    const candidate = join(current, ".pi-langfuse.metadata.json");
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    if (current === root) {
+      break;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+  return undefined;
+}
+
+function readWhitelistedOverrides(cwd: string, gitRoot: string): SourceMetadata {
+  const path = findRepoMetadataFile(cwd, gitRoot);
+  if (!path) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+    const output: SourceMetadata = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (OVERRIDE_KEYS.has(key) && typeof value === "string" && value.trim()) {
+        output[key] = value.trim();
+      }
+    }
+    if (output.repo_name?.includes("/")) {
+      delete output.repo_name;
+    }
+    return output;
+  } catch {
+    return {};
+  }
+}
+
+export function collectSourceMetadata(cwd: string): SourceMetadata {
+  try {
+    const inside = runGit(cwd, ["rev-parse", "--is-inside-work-tree"]);
+    if (inside !== "true") {
+      return nonGitMetadata();
+    }
+
+    const gitRoot = runGit(cwd, ["rev-parse", "--show-toplevel"]);
+    const commit = runGit(cwd, ["rev-parse", "HEAD"]);
+    const branch = runGit(cwd, ["branch", "--show-current"]);
+    const remote = runGit(cwd, ["config", "--get", "remote.origin.url"]);
+    const remoteMetadata = sanitizeGitRemote(remote);
+    const derivedIdentity = deriveIdentity(remoteMetadata.git_remote_path);
+    const overrides = readWhitelistedOverrides(cwd, gitRoot);
+
+    const metadata: SourceMetadata = {
+      source_type: "git-repo",
+      repo_root_name: basename(gitRoot),
+      ...(branch ? { git_branch: branch } : {}),
+      git_commit: commit,
+      ...remoteMetadata,
+      ...derivedIdentity,
+      ...overrides,
+      metadata_source: Object.keys(overrides).length > 0 ? "repo-file" : "git-detection",
+    };
+
+    if (metadata.repo_name?.includes("/")) {
+      delete metadata.repo_name;
+    }
+    if (!metadata.repo_identity && metadata.repo_owner && metadata.repo_name) {
+      metadata.repo_identity = `${metadata.repo_owner}/${metadata.repo_name}`;
+    }
+    return metadata;
+  } catch {
+    return nonGitMetadata();
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,5 +107,6 @@ export interface AgentState {
   generationOrder: string[];
   activeTools: Map<string, ToolState>;
   latestAssistantOutput?: unknown;
+  sourceMetadata?: Record<string, unknown>;
   providerMetadataByRequest: Map<string, Record<string, unknown>>;
 }

--- a/test/source-metadata.test.ts
+++ b/test/source-metadata.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { collectSourceMetadata, sanitizeGitRemote } from "../src/source-metadata.js";
+
+function git(cwd: string, args: string[]) {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+function withTempDir(fn: (root: string) => void) {
+  const root = mkdtempSync(join(tmpdir(), "pi-langfuse-source-metadata-"));
+  try {
+    fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function createRepo(root: string) {
+  const repo = join(root, "repo");
+  mkdirSync(repo);
+  git(repo, ["init"]);
+  git(repo, ["config", "user.email", "test@example.com"]);
+  git(repo, ["config", "user.name", "Test User"]);
+  writeFileSync(join(repo, "README.md"), "test\n");
+  git(repo, ["add", "README.md"]);
+  git(repo, ["commit", "-m", "init"]);
+  return repo;
+}
+
+test("collectSourceMetadata applies whitelist overrides in valid Git repos", () => {
+  withTempDir((root) => {
+    const repo = createRepo(root);
+    git(repo, ["remote", "add", "origin", "https://token:secret@github.com/zyahav/Google-Calendar.git"]);
+    writeFileSync(
+      join(repo, ".pi-langfuse.metadata.json"),
+      JSON.stringify(
+        {
+          repo_identity: "zyahav/Google-Calendar",
+          repo_owner: "zyahav",
+          repo_name: "Google-Calendar",
+          source_type: "git-repo",
+          service_name: "calendar-supervisor",
+          raw_path: "/Users/private/project",
+          token: "secret-token",
+          unknown_key: "must-not-pass",
+          git_remote_path: "evil/override",
+        },
+        null,
+        2,
+      ),
+    );
+
+    const metadata = collectSourceMetadata(repo);
+    assert.equal(metadata.repo_identity, "zyahav/Google-Calendar");
+    assert.equal(metadata.repo_owner, "zyahav");
+    assert.equal(metadata.repo_name, "Google-Calendar");
+    assert.equal(metadata.service_name, "calendar-supervisor");
+    assert.equal(metadata.source_type, "git-repo");
+    assert.equal(metadata.git_remote_host, "github.com");
+    assert.equal(metadata.git_remote_path, "zyahav/Google-Calendar");
+    assert.ok(!metadata.repo_name.includes("/"));
+    assert.ok(!("raw_path" in metadata));
+    assert.ok(!("token" in metadata));
+    assert.ok(!("unknown_key" in metadata));
+  });
+});
+
+test("sanitizeGitRemote strips credentials, protocols, and git suffixes", () => {
+  for (const remote of [
+    "https://token:secret@github.com/zyahav/Google-Calendar.git",
+    "git@github.com:zyahav/Google-Calendar.git",
+    "https://github.com/zyahav/Google-Calendar.git",
+  ]) {
+    const sanitized = sanitizeGitRemote(remote);
+    const serialized = JSON.stringify(sanitized);
+    assert.equal(sanitized.git_remote_host, "github.com");
+    assert.equal(sanitized.git_remote_path, "zyahav/Google-Calendar");
+    assert.ok(!serialized.includes("token"));
+    assert.ok(!serialized.includes("secret"));
+    assert.ok(!serialized.includes("https://"));
+    assert.ok(!serialized.includes("git@"));
+    assert.ok(!serialized.includes(".git"));
+  }
+});
+
+test("collectSourceMetadata keeps repo_name repo-only", () => {
+  withTempDir((root) => {
+    const repo = createRepo(root);
+    git(repo, ["remote", "add", "origin", "https://github.com/zyahav/Google-Calendar.git"]);
+    const metadata = collectSourceMetadata(repo);
+    assert.equal(metadata.repo_identity, "zyahav/Google-Calendar");
+    assert.equal(metadata.repo_owner, "zyahav");
+    assert.equal(metadata.repo_name, "Google-Calendar");
+    assert.ok(!metadata.repo_name.includes("/"));
+  });
+});
+
+test("collectSourceMetadata isolates non-Git folders even with metadata files", () => {
+  withTempDir((root) => {
+    const nonGit = join(root, "non-git");
+    mkdirSync(nonGit);
+    assert.deepEqual(Object.keys(collectSourceMetadata(nonGit)).sort(), ["metadata_source", "source_type"]);
+    writeFileSync(
+      join(nonGit, ".pi-langfuse.metadata.json"),
+      JSON.stringify({ repo_identity: "should/not-pass", repo_owner: "should", repo_name: "not-pass" }),
+    );
+    const nonGitWithFile = collectSourceMetadata(nonGit);
+    assert.deepEqual(Object.keys(nonGitWithFile).sort(), ["metadata_source", "source_type"]);
+    assert.equal(nonGitWithFile.source_type, "non-git");
+    assert.equal(nonGitWithFile.metadata_source, "non-git");
+  });
+});


### PR DESCRIPTION
## Summary\n\nAdds safe source metadata to Pi Langfuse traces so traces can be grouped by Git repository without exposing local paths or credentials.\n\nMetadata includes:\n\n- source_type\n- repo_identity\n- repo_owner\n- repo_name\n- repo_root_name\n- git_branch\n- git_commit\n- git_remote_host\n- git_remote_path\n- metadata_source\n\nRepo-local .pi-langfuse.metadata.json overrides are whitelist-only and are only used after the working directory is confirmed to be inside a usable Git repo. Non-Git folders, missing Git, or Git detection failures emit only source_type=non-git and metadata_source=non-git.\n\n## Privacy / safety\n\n- Does not send raw absolute local paths.\n- Sanitizes remotes to host plus owner/repo path.\n- Strips credentials, protocols, and .git suffixes from remote metadata.\n- Keeps repo_name repo-only, never owner/repo.\n- Ignores unknown repo-local metadata keys.\n- Ignores repo-local metadata identity in non-Git folders.\n\n## Tests\n\nPassed locally:\n\n- npm run typecheck\n- npm test\n\nThe test suite includes coverage for whitelist enforcement, credential stripping, repo_name format, and non-Git isolation.\n\n## Local smoke verification\n\nAlso verified in a real Langfuse trace from another repo. The trace included repo_identity=zyahav/mobile-debug-system and repo_name=mobile-debug-system with sanitized GitHub remote metadata.