### PR TITLE
fix: ignore zeroed cost data from providers like zai

### DIFF
--- a/src/handlers/generation.ts
+++ b/src/handlers/generation.ts
@@ -184,7 +184,7 @@ export async function finishGenerationFromMessage(event: Record<string, unknown>
     model: model || undefined,
     modelParameters,
     usageDetails,
-    costDetails,
+    ...(costDetails ? { costDetails } : {}),
     metadata: {
       ...generation.metadata,
       finishReason: message.finishReason ?? message.stopReason ?? event.finishReason,
@@ -232,7 +232,7 @@ export async function createFallbackGenerationFromTurn(event: Record<string, unk
         model: model || undefined,
         modelParameters,
         usageDetails,
-        costDetails,
+        ...(costDetails ? { costDetails } : {}),
         metadata: captured.metadata,
       },
       asType: "generation",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -400,6 +400,9 @@ export function extractCostDetails(messageOrEvent: Record<string, unknown>): Rec
   const input = Number(cost.input ?? cost.inputCost ?? 0);
   const output = Number(cost.output ?? cost.outputCost ?? 0);
   const total = Number(cost.total ?? cost.totalCost ?? input + output);
+  if (input === 0 && output === 0 && total === 0) {
+    return undefined;
+  }
 
   return { input, output, total };
 }


### PR DESCRIPTION
Z.ai (and potentially other providers) return costDetails with all zeros.

Previously this caused extractCostDetails() to return {input:0, output:0, total:0}, which Langfuse treated as authoritative ingested cost and skipped model inference.

Now zero-cost responses are treated as 'no cost data' so Langfuse can use user-defined model pricing instead.

Fixes cost tracking for GLM-5.2 via Z.ai API.