### PR TITLE
Make payload-shaping limits configurable and disableable via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,27 @@ export LANGFUSE_CAPTURE_CWD=false
 
 All captured payloads are redacted before upload. The extension masks common API keys, bearer tokens, passwords, cookies, private keys, Langfuse keys, GitHub/npm/AWS-style tokens, and local absolute paths.
 
+### Payload limits
+
+Before upload, payloads are shaped: strings are truncated and deeply nested or
+very wide structures are trimmed. These caps keep traces small and protect the
+Langfuse ingestion pipeline. Override any of them (no rebuild needed):
+
+```bash
+export PI_LANGFUSE_MAX_STRING_LENGTH=12000       # per-string chars (system prompt, inputs)
+export PI_LANGFUSE_MAX_TOOL_PAYLOAD_LENGTH=24000 # per tool input/output chars
+export PI_LANGFUSE_MAX_DEPTH=6                    # max nesting depth
+export PI_LANGFUSE_MAX_ARRAY_ITEMS=50            # max array elements kept
+export PI_LANGFUSE_MAX_OBJECT_KEYS=80            # max object keys kept
+export PI_LANGFUSE_MAX_PAYLOAD_NODES=2000        # max total nodes per payload
+```
+
+Set any limit to `0`, `off`, `none`, or `unlimited` to disable that cap
+entirely (captures the full value). Unset or invalid values fall back to the
+defaults shown above. To capture a very large system prompt or big tool
+payloads in full, raise or disable the relevant limit (e.g.
+`PI_LANGFUSE_MAX_STRING_LENGTH=off`).
+
 ### Method 3: Persistent `config.json`
 
 Create or update `~/.pi/agent/pi-langfuse/config.json`:

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ import { CONFIG_PATH, DEFAULT_LANGFUSE_HOST } from "./constants.js";
 import { state } from "./state.js";
 import { forceShutdownRuntime } from "./langfuse.js";
 import { createCapturePolicy, type EnvLike } from "./capture-policy.js";
+import { createPayloadLimits } from "./limits.js";
 
 export function loadConfigFromFile(path = CONFIG_PATH, env: EnvLike = process.env as EnvLike): Config | null {
   if (existsSync(path)) {
@@ -22,6 +23,7 @@ export function loadConfigFromFile(path = CONFIG_PATH, env: EnvLike = process.en
           secretKey: config.secretKey,
           host: config.host || DEFAULT_LANGFUSE_HOST,
           capturePolicy: createCapturePolicy(captureSource),
+          limits: createPayloadLimits(env),
         };
       }
     } catch (e) {
@@ -44,6 +46,7 @@ export function loadConfigFromEnv(env: EnvLike = process.env as EnvLike): Config
     secretKey,
     host: env.LANGFUSE_BASE_URL || env.LANGFUSE_HOST || DEFAULT_LANGFUSE_HOST,
     capturePolicy: createCapturePolicy(env),
+    limits: createPayloadLimits(env),
   };
 }
 

--- a/src/handlers/agent.ts
+++ b/src/handlers/agent.ts
@@ -1,7 +1,7 @@
 import { state, resetRunState, computeEvaluationScores } from "../state.js";
 import { getRuntime, sendScore } from "../langfuse.js";
 import { ensureConfig } from "../config.js";
-import { shapePayload, truncate, extractFinalAssistant, extractAssistantOutput, getCapturePolicy } from "../utils.js";
+import { shapePayload, truncate, extractFinalAssistant, extractAssistantOutput, getCapturePolicy, getLimits } from "../utils.js";
 import { closeDanglingObservations } from "./tool.js";
 import { applyCapturePolicy } from "../capture-policy.js";
 import { collectSourceMetadata } from "../source-metadata.js";
@@ -79,7 +79,7 @@ export async function startAgentRun(event: Record<string, unknown>, ctx: any) {
           ...(state.currentProvider ? { provider: state.currentProvider } : {}),
           sessionId: state.currentSessionId || undefined,
         },
-        systemPrompt: systemPrompt ? truncate(String(systemPrompt), 20000) : undefined,
+        systemPrompt: systemPrompt ? truncate(String(systemPrompt), getLimits().maxString) : undefined,
       },
       getCapturePolicy(),
     );

--- a/src/handlers/tool.ts
+++ b/src/handlers/tool.ts
@@ -10,8 +10,8 @@ import {
   truncate,
   estimatePayloadBytes,
   getCapturePolicy,
+  getLimits,
 } from "../utils.js";
-import { MAX_TOOL_PAYLOAD_LENGTH } from "../constants.js";
 import { applyCapturePolicy } from "../capture-policy.js";
 import { redactString } from "../redaction.js";
 
@@ -28,7 +28,7 @@ export async function startToolObservation(event: Record<string, unknown>) {
   try {
     const toolName = getToolName(event);
     const toolInput = getToolInput(event);
-    const shapedInput = shapePayload(toolInput, { maxString: MAX_TOOL_PAYLOAD_LENGTH });
+    const shapedInput = shapePayload(toolInput, { maxString: getLimits().maxToolPayload });
     const captured = applyCapturePolicy(
       {
         toolInput: shapedInput,
@@ -36,7 +36,7 @@ export async function startToolObservation(event: Record<string, unknown>) {
       },
       getCapturePolicy(),
     );
-    const inputBytes = estimatePayloadBytes(captured.toolInput, MAX_TOOL_PAYLOAD_LENGTH);
+    const inputBytes = estimatePayloadBytes(captured.toolInput, getLimits().maxToolPayload);
     const parent = state.agentState.activeTurn ?? state.agentState.root;
     const tool = await startChildObservation({
       parent,
@@ -79,7 +79,7 @@ export async function finishToolObservation(event: Record<string, unknown>) {
 
   const isError = Boolean(event.isError ?? event.error ?? event.status === "error");
   const output =
-    extractTextContent(event.content, MAX_TOOL_PAYLOAD_LENGTH) ??
+    extractTextContent(event.content, getLimits().maxToolPayload) ??
     event.output ??
     event.result ??
     event.error ??
@@ -87,7 +87,7 @@ export async function finishToolObservation(event: Record<string, unknown>) {
     event;
 
   try {
-    const shapedOutput = shapePayload(output, { maxString: MAX_TOOL_PAYLOAD_LENGTH });
+    const shapedOutput = shapePayload(output, { maxString: getLimits().maxToolPayload });
     const captured = applyCapturePolicy(
       {
         toolOutput: shapedOutput,
@@ -99,7 +99,7 @@ export async function finishToolObservation(event: Record<string, unknown>) {
       },
       getCapturePolicy(),
     );
-    const outputBytes = estimatePayloadBytes(captured.toolOutput, MAX_TOOL_PAYLOAD_LENGTH);
+    const outputBytes = estimatePayloadBytes(captured.toolOutput, getLimits().maxToolPayload);
     const durationMs = Math.max(0, Date.now() - activeTool.startedAt);
 
     activeTool.observation

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -1,0 +1,97 @@
+import {
+  MAX_ARRAY_ITEMS,
+  MAX_DEPTH,
+  MAX_OBJECT_KEYS,
+  MAX_PAYLOAD_NODES,
+  MAX_STRING_LENGTH,
+  MAX_TOOL_PAYLOAD_LENGTH,
+} from "./constants.js";
+import type { EnvLike } from "./capture-policy.js";
+import { state } from "./state.js";
+
+/**
+ * Payload-shaping limits. Every field is a positive integer, or
+ * `Number.POSITIVE_INFINITY` to disable that limit entirely (capture everything).
+ * Resolved once from the environment and stored on the loaded config; consumers
+ * read the resolved values via `getLimits()` rather than the raw constants.
+ */
+export interface PayloadLimits {
+  /** Max characters kept per captured string (generation/agent inputs, outputs, system prompt). */
+  readonly maxString: number;
+  /** Max characters kept for tool inputs/outputs (their payloads run larger than chat strings). */
+  readonly maxToolPayload: number;
+  /** Max nesting depth walked when shaping a structured payload. */
+  readonly maxDepth: number;
+  /** Max array elements kept per array. */
+  readonly maxArrayItems: number;
+  /** Max own-keys kept per object. */
+  readonly maxObjectKeys: number;
+  /** Max total nodes visited across a whole payload before bailing with `[payload too large]`. */
+  readonly maxNodes: number;
+}
+
+export const DEFAULT_LIMITS: PayloadLimits = {
+  maxString: MAX_STRING_LENGTH,
+  maxToolPayload: MAX_TOOL_PAYLOAD_LENGTH,
+  maxDepth: MAX_DEPTH,
+  maxArrayItems: MAX_ARRAY_ITEMS,
+  maxObjectKeys: MAX_OBJECT_KEYS,
+  maxNodes: MAX_PAYLOAD_NODES,
+};
+
+/** Words that mean "no limit" when supplied as an env value. */
+const UNLIMITED_WORDS = new Set(["off", "none", "false", "no", "unlimited", "inf", "infinity"]);
+
+/**
+ * Parse one limit env value.
+ * - unset / blank / unparseable  -> `fallback` (the built-in default)
+ * - "off"/"none"/"unlimited"/... or a value <= 0 -> `Infinity` (limit removed)
+ * - a positive number -> that integer
+ */
+export function parseLimit(raw: string | undefined, fallback: number): number {
+  if (raw === undefined) {
+    return fallback;
+  }
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed === "") {
+    return fallback;
+  }
+  if (UNLIMITED_WORDS.has(trimmed)) {
+    return Number.POSITIVE_INFINITY;
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  if (parsed <= 0) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return Math.floor(parsed);
+}
+
+/**
+ * Resolve payload limits from the environment. Each `PI_LANGFUSE_MAX_*` var overrides
+ * the corresponding default; set any to `0`/`off`/`unlimited` to remove that limit.
+ * Namespaced `PI_LANGFUSE_*` (not `LANGFUSE_*`) to avoid clashing with Langfuse
+ * server env vars such as `LANGFUSE_MAX_EVENT_SIZE_BYTES`.
+ */
+export function createPayloadLimits(env: EnvLike = process.env as EnvLike): PayloadLimits {
+  return {
+    maxString: parseLimit(env.PI_LANGFUSE_MAX_STRING_LENGTH, DEFAULT_LIMITS.maxString),
+    maxToolPayload: parseLimit(env.PI_LANGFUSE_MAX_TOOL_PAYLOAD_LENGTH, DEFAULT_LIMITS.maxToolPayload),
+    maxDepth: parseLimit(env.PI_LANGFUSE_MAX_DEPTH, DEFAULT_LIMITS.maxDepth),
+    maxArrayItems: parseLimit(env.PI_LANGFUSE_MAX_ARRAY_ITEMS, DEFAULT_LIMITS.maxArrayItems),
+    maxObjectKeys: parseLimit(env.PI_LANGFUSE_MAX_OBJECT_KEYS, DEFAULT_LIMITS.maxObjectKeys),
+    maxNodes: parseLimit(env.PI_LANGFUSE_MAX_PAYLOAD_NODES, DEFAULT_LIMITS.maxNodes),
+  };
+}
+
+/**
+ * Resolved limits for the current session: the config-loaded values when a
+ * config is active, otherwise a fresh resolve from the environment. Every
+ * capture/redaction path reads limits through this so a single env change
+ * (or config) governs truncation everywhere.
+ */
+export function getLimits(): PayloadLimits {
+  return state.config?.limits ?? createPayloadLimits();
+}

--- a/src/redaction.ts
+++ b/src/redaction.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { getLimits } from "./limits.js";
 
 export const REDACTED = "[REDACTED_SECRET]";
 
@@ -9,12 +10,15 @@ export interface RedactOptions {
   maxStringLength: number;
 }
 
-const DEFAULT_OPTIONS: RedactOptions = {
-  maxDepth: 6,
-  maxArrayItems: 50,
-  maxObjectKeys: 80,
-  maxStringLength: 12_000,
-};
+function defaultOptions(): RedactOptions {
+  const limits = getLimits();
+  return {
+    maxDepth: limits.maxDepth,
+    maxArrayItems: limits.maxArrayItems,
+    maxObjectKeys: limits.maxObjectKeys,
+    maxStringLength: limits.maxString,
+  };
+}
 
 const SECRET_ASSIGNMENT_RE =
   /\b([A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASS|API[_-]?KEY|PRIVATE[_-]?KEY|AUTH|COOKIE)[A-Z0-9_]*)\s*=\s*([^\s"'`]+)/gi;
@@ -36,7 +40,7 @@ function truncate(value: string, maxStringLength: number): string {
 }
 
 export function redactString(value: string, options: Partial<RedactOptions> = {}): string {
-  const merged = { ...DEFAULT_OPTIONS, ...options };
+  const merged = { ...defaultOptions(), ...options };
   const truncated = truncate(value, merged.maxStringLength);
   return truncated
     .replace(PRIVATE_KEY_RE, REDACTED)
@@ -110,6 +114,6 @@ function visit(value: unknown, options: RedactOptions, depth: number, seen: Weak
 }
 
 export function redactValue(value: unknown, options: Partial<RedactOptions> = {}): unknown {
-  const merged: RedactOptions = { ...DEFAULT_OPTIONS, ...options };
+  const merged: RedactOptions = { ...defaultOptions(), ...options };
   return visit(value, merged, merged.maxDepth, new WeakSet<object>());
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,12 @@
 import type { CapturePolicy } from "./capture-policy.js";
+import type { PayloadLimits } from "./limits.js";
 
 export interface Config {
   publicKey: string;
   secretKey: string;
   host: string;
   capturePolicy?: CapturePolicy;
+  limits?: PayloadLimits;
 }
 
 export interface LangfuseObservation {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,4 @@
-import {
-  MAX_ARRAY_ITEMS,
-  MAX_DEPTH,
-  MAX_OBJECT_KEYS,
-  MAX_PAYLOAD_NODES,
-  MAX_STRING_LENGTH,
-  MAX_TOOL_PAYLOAD_LENGTH,
-} from "./constants.js";
+import { getLimits } from "./limits.js";
 import { createCapturePolicy, type CapturePolicy } from "./capture-policy.js";
 import { redactValue } from "./redaction.js";
 import { state } from "./state.js";
@@ -14,7 +7,9 @@ export function getCapturePolicy(): CapturePolicy {
   return state.config?.capturePolicy ?? createCapturePolicy();
 }
 
-export function truncate(value: string, maxLength = MAX_STRING_LENGTH): string {
+export { getLimits };
+
+export function truncate(value: string, maxLength = getLimits().maxString): string {
   return value.length > maxLength ? `${value.slice(0, maxLength)}... [truncated]` : value;
 }
 
@@ -35,11 +30,22 @@ const PAYLOAD_TOO_LARGE = "[payload too large]";
 
 export function shapePayload(
   value: unknown,
-  options: { maxString?: number; depth?: number; maxNodes?: number; redact?: boolean; parseJson?: boolean } = {},
+  options: {
+    maxString?: number;
+    depth?: number;
+    maxNodes?: number;
+    maxArrayItems?: number;
+    maxObjectKeys?: number;
+    redact?: boolean;
+    parseJson?: boolean;
+  } = {},
 ): unknown {
-  const maxString = options.maxString ?? MAX_STRING_LENGTH;
-  const depth = options.depth ?? MAX_DEPTH;
-  const maxNodes = options.maxNodes ?? MAX_PAYLOAD_NODES;
+  const limits = getLimits();
+  const maxString = options.maxString ?? limits.maxString;
+  const depth = options.depth ?? limits.maxDepth;
+  const maxNodes = options.maxNodes ?? limits.maxNodes;
+  const maxArrayItems = options.maxArrayItems ?? limits.maxArrayItems;
+  const maxObjectKeys = options.maxObjectKeys ?? limits.maxObjectKeys;
   const budget = { exhausted: false, nodeCount: 0 };
 
   function visit(item: unknown, remainingDepth: number, seen: WeakSet<object>): unknown {
@@ -88,7 +94,7 @@ export function shapePayload(
 
     if (Array.isArray(item)) {
       const output: unknown[] = [];
-      const limit = Math.min(item.length, MAX_ARRAY_ITEMS);
+      const limit = Math.min(item.length, maxArrayItems);
       for (let index = 0; index < limit; index++) {
         output.push(visit(item[index], remainingDepth - 1, seen));
         if (budget.exhausted) {
@@ -120,7 +126,7 @@ export function shapePayload(
         }
         output[key] = visit((item as Record<string, unknown>)[key], remainingDepth - 1, seen);
         keyCount++;
-        if (budget.exhausted || keyCount >= MAX_OBJECT_KEYS) {
+        if (budget.exhausted || keyCount >= maxObjectKeys) {
           break;
         }
       }
@@ -136,12 +142,12 @@ export function shapePayload(
     : redactValue(shaped, {
         maxDepth: depth,
         maxStringLength: maxString,
-        maxArrayItems: MAX_ARRAY_ITEMS,
-        maxObjectKeys: MAX_OBJECT_KEYS,
+        maxArrayItems,
+        maxObjectKeys,
       });
 }
 
-export function safeSerialize(value: unknown, maxLength = MAX_TOOL_PAYLOAD_LENGTH): string {
+export function safeSerialize(value: unknown, maxLength = getLimits().maxToolPayload): string {
   try {
     return truncate(JSON.stringify(shapePayload(value, { maxString: maxLength }), null, 2), maxLength);
   } catch {
@@ -149,7 +155,7 @@ export function safeSerialize(value: unknown, maxLength = MAX_TOOL_PAYLOAD_LENGT
   }
 }
 
-export function estimatePayloadBytes(value: unknown, maxLength = MAX_TOOL_PAYLOAD_LENGTH): number {
+export function estimatePayloadBytes(value: unknown, maxLength = getLimits().maxToolPayload): number {
   return new TextEncoder().encode(safeSerialize(value, maxLength)).length;
 }
 

--- a/test/limits.test.ts
+++ b/test/limits.test.ts
@@ -1,0 +1,98 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createPayloadLimits, parseLimit, DEFAULT_LIMITS } from "../src/limits.ts";
+import { shapePayload } from "../src/utils.ts";
+import { redactValue } from "../src/redaction.ts";
+
+test("createPayloadLimits returns the built-in defaults when env is empty", () => {
+  assert.deepEqual(createPayloadLimits({}), DEFAULT_LIMITS);
+});
+
+test("createPayloadLimits reads every PI_LANGFUSE_MAX_* override", () => {
+  const limits = createPayloadLimits({
+    PI_LANGFUSE_MAX_STRING_LENGTH: "500",
+    PI_LANGFUSE_MAX_TOOL_PAYLOAD_LENGTH: "1000",
+    PI_LANGFUSE_MAX_DEPTH: "3",
+    PI_LANGFUSE_MAX_ARRAY_ITEMS: "10",
+    PI_LANGFUSE_MAX_OBJECT_KEYS: "20",
+    PI_LANGFUSE_MAX_PAYLOAD_NODES: "100",
+  });
+  assert.deepEqual(limits, {
+    maxString: 500,
+    maxToolPayload: 1000,
+    maxDepth: 3,
+    maxArrayItems: 10,
+    maxObjectKeys: 20,
+    maxNodes: 100,
+  });
+});
+
+test("a limit set to 0 / off / unlimited / negative is removed (Infinity)", () => {
+  for (const value of ["0", "off", "none", "false", "no", "unlimited", "infinity", "-1", "-42"]) {
+    assert.equal(
+      createPayloadLimits({ PI_LANGFUSE_MAX_STRING_LENGTH: value }).maxString,
+      Number.POSITIVE_INFINITY,
+      `value ${JSON.stringify(value)} should disable the limit`,
+    );
+  }
+});
+
+test("blank or unparseable env falls back to the default", () => {
+  assert.equal(createPayloadLimits({ PI_LANGFUSE_MAX_DEPTH: "" }).maxDepth, DEFAULT_LIMITS.maxDepth);
+  assert.equal(createPayloadLimits({ PI_LANGFUSE_MAX_DEPTH: "   " }).maxDepth, DEFAULT_LIMITS.maxDepth);
+  assert.equal(createPayloadLimits({ PI_LANGFUSE_MAX_DEPTH: "abc" }).maxDepth, DEFAULT_LIMITS.maxDepth);
+});
+
+test("parseLimit floors fractional positives", () => {
+  assert.equal(parseLimit("12.9", 5), 12);
+});
+
+test("shapePayload keeps the default array cap, and honors an override that removes it", () => {
+  const arr = Array.from({ length: 120 }, (_, index) => index);
+
+  const capped = shapePayload(arr) as unknown[];
+  assert.equal(capped.length, DEFAULT_LIMITS.maxArrayItems, "default caps arrays at 50");
+
+  const uncapped = shapePayload(arr, { maxArrayItems: Number.POSITIVE_INFINITY }) as unknown[];
+  assert.equal(uncapped.length, 120, "an unlimited maxArrayItems keeps every element");
+});
+
+test("shapePayload honors an overridden maxObjectKeys", () => {
+  const obj: Record<string, number> = Object.create(null);
+  for (let index = 0; index < 200; index++) {
+    obj[`k${index}`] = index;
+  }
+
+  const uncapped = shapePayload(obj, { maxObjectKeys: Number.POSITIVE_INFINITY }) as Record<string, number>;
+  assert.equal(Object.keys(uncapped).length, 200);
+});
+
+test("shapePayload honors an overridden maxString (no truncation when unlimited)", () => {
+  const big = "x".repeat(50_000);
+  const shaped = shapePayload(big, { maxString: Number.POSITIVE_INFINITY, parseJson: false }) as string;
+  assert.equal(shaped.length, 50_000);
+  assert.ok(!shaped.includes("[truncated]"));
+});
+
+test("redaction defaults follow the configurable maxString (system-prompt regression)", () => {
+  // The capture pipeline calls redactValue() with no options for systemPrompt,
+  // input, output and tool IO; its defaults must track the resolved limits, or
+  // the system prompt gets clipped at the old hardcoded 12000 regardless of env.
+  const big = "s".repeat(30000);
+  const saved = process.env.PI_LANGFUSE_MAX_STRING_LENGTH;
+  const marker = "... [truncated]".length;
+  try {
+    delete process.env.PI_LANGFUSE_MAX_STRING_LENGTH;
+    assert.equal((redactValue(big) as string).length, DEFAULT_LIMITS.maxString + marker, "default clips at 12000");
+
+    process.env.PI_LANGFUSE_MAX_STRING_LENGTH = "off";
+    assert.equal((redactValue(big) as string).length, 30000, "off keeps the full string");
+  } finally {
+    if (saved === undefined) {
+      delete process.env.PI_LANGFUSE_MAX_STRING_LENGTH;
+    } else {
+      process.env.PI_LANGFUSE_MAX_STRING_LENGTH = saved;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
pi-langfuse shapes captured payloads with fixed limits — strings truncated at 12000 chars, arrays at 50 items, objects at 80 keys, depth 6, 2000 nodes. They're hardcoded module constants, so raising or removing any of them means patching the code instead of configuring the plugin. This PR makes all six resolvable from the environment with a clean disable value, and keeps the current defaults when nothing is set.

## Motivation
The 12000-char string cap silently truncates large captures — most visibly a big system prompt — with no supported way to raise it. It also exposed a subtler issue: the string cap was enforced in two independent places, so a caller passing a higher limit still got re-clipped at 12000 by the redaction defaults (fixed below).

## What changed
- **New `src/limits.ts`** — `PayloadLimits` type, `DEFAULT_LIMITS` (the existing constants), a `createPayloadLimits(env)` resolver, and `getLimits()` (`config.limits ?? env`) as the single source every capture path reads.
- **Six env vars** — `PI_LANGFUSE_MAX_STRING_LENGTH`, `PI_LANGFUSE_MAX_TOOL_PAYLOAD_LENGTH`, `PI_LANGFUSE_MAX_DEPTH`, `PI_LANGFUSE_MAX_ARRAY_ITEMS`, `PI_LANGFUSE_MAX_OBJECT_KEYS`, `PI_LANGFUSE_MAX_PAYLOAD_NODES`. Set any to `0` / `off` / `none` / `unlimited` to remove that cap; unset or invalid falls back to the default. Namespaced `PI_LANGFUSE_*` to avoid clashing with Langfuse server vars (e.g. `LANGFUSE_MAX_EVENT_SIZE_BYTES`).
- **Threaded through** `truncate`, `shapePayload` (now also honors `maxArrayItems`/`maxObjectKeys` options), `safeSerialize`, `estimatePayloadBytes`, and the handler capture sites.
- **Bug fix in `redaction.ts`** — its `DEFAULT_OPTIONS` hardcoded the same limits, and `applyCapturePolicy` calls `redactValue`/`redactString` with no options for `systemPrompt`/`input`/`output`/tool IO, so those were re-clipped at 12000 regardless of the caller's limit. `redaction` now resolves its defaults from `getLimits()`, so the config governs every path.
- **README** — documents the env vars and disable semantics.

## Backward compatibility
No behavior change without env vars — `DEFAULT_LIMITS` is the original constants. A test asserts the default still clips at 12000.

## Tests
`test/limits.test.ts`: env resolution, each disable keyword, negative/invalid handling, `shapePayload` honoring overrides, and a regression test that the redaction path follows the configured `maxString`. `npm test` green, `tsc --noEmit` clean.
