### PR TITLE
fix: use logical Pi session ID for ephemeral runs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,7 +30,7 @@ Recommended checks while working on the extension:
 
 ```bash
 npm run typecheck
-node --test test/*.test.ts
+npm test
 ```
 
 Basic manual validation:
@@ -217,7 +217,7 @@ Recommended checks after substantive changes:
 
 ```bash
 npm run typecheck
-node --test test/*.test.ts
+npm test
 ```
 
 For integration-sensitive changes, also run Pi with the extension enabled and verify:

--- a/DEVELOPMENT_CN.md
+++ b/DEVELOPMENT_CN.md
@@ -30,7 +30,7 @@ pi link /path/to/pi-langfuse
 
 ```bash
 npm run typecheck
-node --test test/*.test.ts
+npm test
 ```
 
 基础手动验证：
@@ -217,7 +217,7 @@ Trace (name: "pi-agent")
 
 ```bash
 npm run typecheck
-node --test test/*.test.ts
+npm test
 ```
 
 如果改动涉及集成行为，还需要启用扩展运行 Pi，并额外确认：

--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,7 @@
  */
 
 import { basename } from "node:path";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 import { state, resetRunState, runWithSession, setCurrentSession } from "./src/state.js";
 import { ensureConfig, promptForConfig, loadConfig } from "./src/config.js";
@@ -74,10 +74,18 @@ export default async function (pi: ExtensionAPI) {
     },
   });
 
-  const getSessionId = (ctx?: any) => {
+  const getSessionId = (ctx?: unknown): string | undefined => {
     try {
-      const sessionFile = ctx?.sessionManager?.getSessionFile?.();
-      return sessionFile ? basename(sessionFile, ".jsonl") : undefined;
+      const sessionManager = (ctx as ExtensionContext | undefined)?.sessionManager;
+      const sessionId = sessionManager?.getSessionId?.();
+      if (typeof sessionId === "string" && sessionId) {
+        return sessionId;
+      }
+
+      const sessionFile = sessionManager?.getSessionFile?.();
+      return typeof sessionFile === "string" && sessionFile
+        ? basename(sessionFile, ".jsonl")
+        : undefined;
     } catch {
       return undefined;
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4,8 +4,11 @@ import { readFile } from "node:fs/promises";
 
 import registerExtension from "../index.ts";
 import { __setRuntimeForTest } from "../src/langfuse.ts";
-import { state } from "../src/state.ts";
+import { clearAllSessionStates, state } from "../src/state.ts";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { LangfuseRuntime } from "../src/types.ts";
+
+type ExtensionHandler = Parameters<ExtensionAPI["on"]>[1];
 
 test("agent_end waits for runtime shutdown", async () => {
   const handlers = new Map<string, (event: Record<string, unknown>, ctx: unknown) => Promise<void>>();
@@ -65,6 +68,72 @@ test("agent_end waits for runtime shutdown", async () => {
       releaseForceFlush();
     }
     __setRuntimeForTest(null);
+    state.config = previousConfig;
+  }
+});
+
+void test("uses logical Pi session IDs with the legacy file fallback", async () => {
+  const handlers = new Map<string, ExtensionHandler>();
+  const propagatedSessionIds: (string | undefined)[] = [];
+  const previousConfig = state.config;
+  const observation = {
+    id: "observation-id",
+    traceId: "trace-id",
+    update() {
+      return this;
+    },
+    end() {
+      return undefined;
+    },
+  };
+  const runtime: LangfuseRuntime = {
+    startObservation: () => observation,
+    propagateAttributes: (attributes, fn) => {
+      propagatedSessionIds.push(attributes.sessionId);
+      return fn();
+    },
+    scoreClient: {},
+  };
+
+  try {
+    state.config = {
+      publicKey: "pk_test",
+      secretKey: "sk_test",
+      host: "https://example.com",
+    };
+    __setRuntimeForTest(runtime);
+    await registerExtension({
+      registerCommand() {
+        return undefined;
+      },
+      on(name, handler) {
+        handlers.set(name, handler);
+      },
+    });
+
+    const beforeAgentStart = handlers.get("before_agent_start");
+    assert.ok(beforeAgentStart);
+
+    await beforeAgentStart({ prompt: "test" }, {
+      sessionManager: {
+        getSessionId: () => "00000000-0000-7000-8000-000000000003",
+        getSessionFile: () => undefined,
+      },
+    });
+
+    await beforeAgentStart({ prompt: "legacy test" }, {
+      sessionManager: {
+        getSessionFile: () => "/sessions/legacy-session.jsonl",
+      },
+    });
+
+    assert.deepEqual(propagatedSessionIds, [
+      "00000000-0000-7000-8000-000000000003",
+      "legacy-session",
+    ]);
+  } finally {
+    __setRuntimeForTest(null);
+    clearAllSessionStates();
     state.config = previousConfig;
   }
 });

--- a/types/pi-coding-agent.d.ts
+++ b/types/pi-coding-agent.d.ts
@@ -1,4 +1,11 @@
 declare module "@earendil-works/pi-coding-agent" {
+  export interface ExtensionContext {
+    sessionManager?: {
+      getSessionId?: () => unknown;
+      getSessionFile?: () => unknown;
+    };
+  }
+
   export interface ExtensionAPI {
     on(event: string, handler: (event: any, ctx: any) => unknown): void;
     registerCommand(


### PR DESCRIPTION
## Summary

Use Pi's public `sessionManager.getSessionId()` for Langfuse session grouping, with the existing `getSessionFile()` behavior as a compatibility fallback.

A minor error in `DEVELOPER.md` is fixed---the as-stated test command needed a small edit.

## Motivation

pi-langfuse currently derives session identity from `getSessionFile()`. This value is undefined when Pi runs in `--no-session` mode, whereas `getSessionId()` returns a valid session UUID in both persisted and ephemeral sessions.

Pi's session filename includes a timestamp, so the two methods return different values. Because `getSessionId()` was added in Pi 0.7.8, the `getSessionFile()` fallback is preserved for compatibility. pi-langfuse treats session identity as opaque; it does not extract or otherwise depend on the timestamp.

## Compatibility

- New traces for persisted sessions use `<uuid>` instead of `<timestamp>_<uuid>`.
- Historical traces retain their filename-derived session IDs. Therefore, an active Pi session spanning the upgrade will appear in two Langfuse session groups.
- Contexts without `getSessionId()` retain the exact previous file-basename behavior.
- Capture policy, trace shape, shutdown, and environment-variable behavior are unchanged.

## Testing

The regression test exercises the public Pi context boundary with:

- an in-memory session where `getSessionId()` is available and `getSessionFile()` is undefined
- a compatibility context without `getSessionId()` and with a session file
- synthetic identifiers, a fake Langfuse runtime, trace-level attribute assertions, and explicit session-state cleanup

Validation followed `DEVELOPMENT.md`:

- focused `test/index.test.ts` — 3 passed
- `npm run typecheck` — passed
- `npm test` — 61 passed
- manual Pi/Langfuse run — one trace created; root input/output populated; generations and the intentional failing tool call correctly parented; tool failure marked `ERROR`; trace visible after shutdown; JSON session UUID exactly matched the Langfuse `sessionId`
- trace-level scores were absent in both this candidate and an unchanged v1.5.9 baseline in the live environment, so this is not introduced by the session-ID patch. Follow-up #10 fixes this pre-existing score-ingestion issue; with that patch, all five trace-level scores and the failed-tool score pass manual validation

## Development disclosure

This PR was developed with assistance from AI tooling. I reviewed it in full and take responsibility for the contribution.
