### PR TITLE
fix: include score IDs in ingestion

### DIFF
--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -219,6 +219,9 @@ async function flushPendingScores(rt: LangfuseRuntime, signal: AbortSignal): Pro
 
   while (pendingScores.length > 0) {
     const scores = pendingScores.slice(0, MAX_SCORE_BATCH_SIZE);
+    for (const score of scores) {
+      score.id ??= randomUUID();
+    }
     try {
       const errors = await ingestBatch(
         rt,

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,7 @@ export interface LangfuseScoreClient {
 }
 
 export interface PendingScore {
+  id?: string;
   traceId?: string;
   sessionId?: string;
   observationId?: string;

--- a/test/langfuse.test.ts
+++ b/test/langfuse.test.ts
@@ -394,9 +394,10 @@ test("failed score ingestion keeps the batch queued", async () => {
   }
 });
 
-test("shutdown aborts an active score request and retries within its deadline", async () => {
+test("shutdown aborts an active score request and retries with a stable score ID", async () => {
   let calls = 0;
   let firstRequestAborted = false;
+  const scoreIds: unknown[] = [];
   const originalFetch = globalThis.fetch;
   const previousConfig = state.config;
   const runtime = createTestRuntime({
@@ -412,6 +413,10 @@ test("shutdown aborts an active score request and retries within its deadline", 
   });
   globalThis.fetch = ((_input, init) => {
     calls += 1;
+    const request = JSON.parse(String(init?.body)) as {
+      batch: Array<{ body: { id?: unknown } }>;
+    };
+    scoreIds.push(request.batch[0]?.body.id);
     if (calls === 1) {
       return new Promise<Response>((_resolve, reject) => {
         init?.signal?.addEventListener("abort", () => {
@@ -434,6 +439,8 @@ test("shutdown aborts an active score request and retries within its deadline", 
 
     assert.equal(firstRequestAborted, true);
     assert.equal(calls, 2);
+    assert.equal(typeof scoreIds[0], "string");
+    assert.deepEqual(scoreIds, [scoreIds[0], scoreIds[0]]);
     assert.deepEqual(runtime.pendingScores, []);
   } finally {
     await disposeTestRuntime(runtime);


### PR DESCRIPTION
## Summary

Ensure each queued score has a stable entity ID before legacy batch ingestion. Retries reuse the same score ID while retaining separate event-envelope IDs.

## Motivation

Langfuse accepts score envelopes without `body.id` and reports them as successful, but no score is stored. The patch emulates the official Langfuse client—UUIDs are generated and included in the request. With this fix, trace- and observation-level scores are correctly reported.

## Compatibility

No documented public API or configuration changes. Existing batching, queue limits, score fields, timeouts, and shutdown behavior remain unchanged. An optional internal field preserves compatibility with existing queued-score fixtures.

## Testing

- `npm run typecheck`
- `npm test` — 60 tests passed
- Full Pi/Langfuse validation — all five trace-level scores and the failed-tool score materialized with the correct subjects; this is the score validation currently fails on v1.5.9 and that failed during #9
- This patch does not modify development guidance.

## Development disclosure

This draft was developed with assistance from AI tooling. Full human review is pending before upstream submission.
