### PR TITLE
fix: capture the system prompt after extension overrides are applied

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,7 +16,7 @@ import { shutdownRuntime } from "./src/langfuse.js";
 import { handleLangfusePrivacyCommand, handleLangfuseStatusCommand, handleLangfuseTestCommand } from "./src/commands.js";
 import { getMessageFromEvent, extractAssistantOutput, getCapturePolicy } from "./src/utils.js";
 import { applyCapturePolicy } from "./src/capture-policy.js";
-import { startAgentRun, finishAgentRun } from "./src/handlers/agent.js";
+import { startAgentRun, finishAgentRun, recordSystemPrompt } from "./src/handlers/agent.js";
 import { startTurnObservation, finishTurnObservation } from "./src/handlers/turn.js";
 import {
   startGeneration,
@@ -104,6 +104,9 @@ export default async function (pi: ExtensionAPI) {
     if (!state.agentState?.root) {
       await startAgentRun(event, ctx);
     }
+    // The system prompt is only final here: before_agent_start handlers that
+    // run after this extension may still rewrite it.
+    await recordSystemPrompt(ctx);
   }));
 
   pi.on("turn_start", async (event, ctx) => withSession(ctx, async () => {

--- a/src/handlers/agent.ts
+++ b/src/handlers/agent.ts
@@ -54,15 +54,6 @@ export async function startAgentRun(event: Record<string, unknown>, ctx: any) {
       state.currentProvider = ctx.model.provider || "";
     }
 
-    let systemPrompt = undefined;
-    try {
-      if (ctx.getSystemPrompt) {
-        systemPrompt = await ctx.getSystemPrompt();
-      }
-    } catch {
-      // Ignore if getSystemPrompt is not available or fails
-    }
-
     const rawPromptInput = shapePayload({
       prompt: event.prompt,
       images: event.images,
@@ -79,7 +70,6 @@ export async function startAgentRun(event: Record<string, unknown>, ctx: any) {
           ...(state.currentProvider ? { provider: state.currentProvider } : {}),
           sessionId: state.currentSessionId || undefined,
         },
-        systemPrompt: systemPrompt ? truncate(String(systemPrompt), getLimits().maxString) : undefined,
       },
       getCapturePolicy(),
     );
@@ -106,10 +96,7 @@ export async function startAgentRun(event: Record<string, unknown>, ctx: any) {
           "pi-agent",
             {
               input: captured.input,
-              metadata: {
-                ...(captured.metadata ?? {}),
-                ...(captured.systemPrompt ? { systemPrompt: captured.systemPrompt } : {}),
-              },
+              metadata: captured.metadata ?? {},
             },
           { asType: "agent" },
         ),
@@ -121,6 +108,49 @@ export async function startAgentRun(event: Record<string, unknown>, ctx: any) {
   } catch (e) {
     console.warn("📊 Langfuse: Failed to create agent observation", e);
     state.isTracingDisabled = true;
+  }
+}
+
+/**
+ * Records the effective system prompt on the root agent observation.
+ *
+ * Deliberately called from `agent_start` rather than `before_agent_start`:
+ * during `before_agent_start` the extension runner hands each handler the
+ * prompt as it stands mid-chain, so extensions registered after this one
+ * (e.g. inline factories that rewrite the system prompt) are not reflected
+ * yet. By `agent_start` the session has applied the final override, and
+ * `ctx.getSystemPrompt()` returns the prompt actually sent to the model.
+ */
+export async function recordSystemPrompt(ctx: any) {
+  const root = state.agentState?.root;
+  if (state.isTracingDisabled || !root) {
+    return;
+  }
+
+  let systemPrompt = undefined;
+  try {
+    if (ctx.getSystemPrompt) {
+      systemPrompt = await ctx.getSystemPrompt();
+    }
+  } catch {
+    // Ignore if getSystemPrompt is not available or fails
+  }
+  if (!systemPrompt) {
+    return;
+  }
+
+  const captured = applyCapturePolicy(
+    { systemPrompt: truncate(String(systemPrompt), getLimits().maxString) },
+    getCapturePolicy(),
+  );
+  if (!captured.systemPrompt) {
+    return;
+  }
+
+  try {
+    root.update({ metadata: { systemPrompt: captured.systemPrompt } });
+  } catch (e) {
+    console.warn("\u{1F4CA} Langfuse: Failed to record system prompt", e);
   }
 }
 

--- a/test/system-prompt-capture.test.ts
+++ b/test/system-prompt-capture.test.ts
@@ -1,0 +1,97 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { recordSystemPrompt } from "../src/handlers/agent.ts";
+import { createCapturePolicy } from "../src/capture-policy.ts";
+import {
+  clearAllSessionStates,
+  setCurrentSession,
+  state,
+} from "../src/state.ts";
+import type { AgentState, Config, LangfuseObservation, ObservationUpdate } from "../src/types.js";
+
+class FakeObservation implements LangfuseObservation {
+  id = "fake-observation";
+  traceId = "fake-trace";
+  updates: Array<ObservationUpdate | undefined> = [];
+  children: FakeObservation[] = [];
+  ended = false;
+
+  constructor(public body?: ObservationUpdate) {}
+
+  update(body?: ObservationUpdate): LangfuseObservation {
+    this.updates.push(body);
+    return this;
+  }
+
+  end(body?: ObservationUpdate): void {
+    if (body) {
+      this.updates.push(body);
+    }
+    this.ended = true;
+  }
+
+  startObservation(_name: string, body?: ObservationUpdate): LangfuseObservation {
+    const child = new FakeObservation(body);
+    this.children.push(child);
+    return child;
+  }
+}
+
+function makeAgentState(root: LangfuseObservation): AgentState {
+  return {
+    root,
+    generationSeq: 0,
+    activeGenerations: new Map(),
+    generationOrder: [],
+    activeTools: new Map(),
+    providerMetadataByRequest: new Map(),
+  };
+}
+
+test("recordSystemPrompt captures the prompt as it stands when called, not an earlier snapshot", async () => {
+  clearAllSessionStates();
+  setCurrentSession("system-prompt-test");
+
+  const root = new FakeObservation();
+  state.agentState = makeAgentState(root);
+
+  // Simulates a session where a later before_agent_start extension rewrote
+  // the system prompt: by agent_start, ctx.getSystemPrompt() returns the
+  // final override rather than the original assembled prompt.
+  const rawPrompt = "You are an agent.\n\nGuidelines:\n- Be concise";
+  const shapedPrompt = "You are an agent.";
+  let currentPrompt = rawPrompt;
+  const ctx = { getSystemPrompt: () => currentPrompt };
+
+  currentPrompt = shapedPrompt;
+  await recordSystemPrompt(ctx);
+
+  assert.equal(root.updates.length, 1);
+  assert.equal(root.updates[0]?.metadata?.systemPrompt, shapedPrompt);
+  assert.ok(!String(root.updates[0]?.metadata?.systemPrompt).includes("Guidelines"));
+});
+
+test("recordSystemPrompt respects the captureSystemPrompt policy", async () => {
+  clearAllSessionStates();
+  setCurrentSession("system-prompt-test");
+
+  const root = new FakeObservation();
+  state.agentState = makeAgentState(root);
+  state.config = {
+    capturePolicy: createCapturePolicy({ LANGFUSE_PRIVACY_PRESET: "metadata-only" }),
+  } as Config;
+
+  await recordSystemPrompt({ getSystemPrompt: () => "secret system prompt" });
+
+  assert.equal(root.updates.length, 0);
+});
+
+test("recordSystemPrompt is a no-op without an active agent observation", async () => {
+  clearAllSessionStates();
+  setCurrentSession("system-prompt-test");
+
+  await recordSystemPrompt({ getSystemPrompt: () => "prompt" });
+  // No agentState.root — nothing to update, and no crash.
+  assert.equal(state.agentState, null);
+});


### PR DESCRIPTION
Fixes #12.

## Problem

`startAgentRun` snapshotted `ctx.getSystemPrompt()` inside `before_agent_start`, where Pi's extension runner hands each handler the prompt as it stands mid-chain. Extensions registered after pi-langfuse (notably inline `extensionFactories`, which `DefaultResourceLoader` always appends last) can still rewrite the prompt — so traces recorded a system prompt the model never received.

## Fix

Move the capture into a new `recordSystemPrompt(ctx)` called from the existing `agent_start` handler. By then the session has applied the final override, and `ctx.getSystemPrompt()` returns the prompt actually sent to the model.

Behaviour is otherwise unchanged:
- the value still flows through the capture policy (`captureSystemPrompt`, redaction, truncation via `getLimits().maxString`);
- it lands in the same `systemPrompt` key of the root observation's metadata (`root.update({ metadata })` merges with the metadata set at `startObservation`);
- headless/fallback runs are covered because `agent_start` already calls `startAgentRun` first when no root exists.

## Tests

`test/system-prompt-capture.test.ts`:
- captures the prompt as it stands at call time (regression for the mid-chain snapshot);
- respects `captureSystemPrompt=false` (metadata-only preset);
- no-op without an active agent observation.

`npm test`: 63/63 pass; `tsc --noEmit` clean.