### PR TITLE
fix: classify shutdown deadline AbortError

### DIFF
--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -139,7 +139,19 @@ export function getLastRuntimeError(): { scope: string; message: string; timesta
   return lastRuntimeError;
 }
 
-async function withShutdownDeadline<T>(label: string, startOperation: () => Promise<T> | undefined, deadline: number): Promise<T | undefined> {
+function isExpectedShutdownAbort(error: unknown, signal: AbortSignal): boolean {
+  return signal.aborted
+    && error === signal.reason
+    && error instanceof Error
+    && error.name === "AbortError";
+}
+
+async function withShutdownDeadline<T>(
+  label: string,
+  startOperation: () => Promise<T> | undefined,
+  deadline: number,
+  expectedAbortSignal?: AbortSignal,
+): Promise<T | undefined> {
   const remainingMs = deadline - Date.now();
   if (remainingMs <= 0) {
     debugLog(`📊 Langfuse: Skipped ${label}; shutdown deadline elapsed`);
@@ -162,6 +174,12 @@ async function withShutdownDeadline<T>(label: string, startOperation: () => Prom
         }, remainingMs);
       }),
     ]);
+  } catch (error) {
+    if (expectedAbortSignal && isExpectedShutdownAbort(error, expectedAbortSignal)) {
+      debugLog(`📊 Langfuse: ${label} aborted; shutdown deadline elapsed`);
+      return undefined;
+    }
+    throw error;
   } finally {
     if (timeout) {
       clearTimeout(timeout);
@@ -670,6 +688,7 @@ function doShutdownRuntime(): Promise<void> {
         "REST fallback ingestion",
         () => fallbackToRestIngestion(rt, controller.signal),
         deadline,
+        controller.signal,
       );
       await withShutdownDeadline("Langfuse score flush", () => rt.scoreClient.flush?.(), deadline);
       await withShutdownDeadline("Langfuse client shutdown", () => rt.scoreClient.shutdown?.(), deadline);

--- a/test/langfuse.test.ts
+++ b/test/langfuse.test.ts
@@ -7,6 +7,7 @@ import {
   __setRuntimeForTest,
   ensureOtelContextManager,
   forceShutdownRuntime,
+  getLastRuntimeError,
   getRuntime,
   sendScore,
 } from "../src/langfuse.ts";
@@ -726,6 +727,91 @@ test("REST fallback checks visibility and ingests the trace through abortable HT
   } finally {
     __setRuntimeForTest(null);
     globalThis.fetch = originalFetch;
+  }
+});
+
+test("shutdown treats its controller AbortError as an expected deadline", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalWarn = console.warn;
+  const previousError = getLastRuntimeError();
+  const warnings: unknown[][] = [];
+  const runtime = createTestRuntime({
+    runtimeConfig: {
+      publicKey: "pk-test",
+      secretKey: "sk-test",
+      host: "https://example.com",
+    },
+    restFallback: {
+      trace: {
+        id: "deadline-trace",
+        timestamp: new Date().toISOString(),
+        name: "pi-agent",
+      },
+      observations: [],
+      observationById: new Map(),
+      attempted: false,
+    },
+  });
+  globalThis.fetch = ((_input, init) => new Promise<Response>((_resolve, reject) => {
+    const signal = init?.signal;
+    signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+  })) as typeof fetch;
+  console.warn = (...args: unknown[]) => warnings.push(args);
+
+  try {
+    __setRuntimeForTest(runtime, 50);
+    await forceShutdownRuntime();
+
+    assert.equal(warnings.length, 0);
+    assert.equal(getLastRuntimeError(), previousError);
+  } finally {
+    __setRuntimeForTest(null);
+    globalThis.fetch = originalFetch;
+    console.warn = originalWarn;
+  }
+});
+
+test("shutdown still reports an unrelated AbortError", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalWarn = console.warn;
+  const warnings: unknown[][] = [];
+  const runtime = createTestRuntime({
+    runtimeConfig: {
+      publicKey: "pk-test",
+      secretKey: "sk-test",
+      host: "https://example.com",
+    },
+    restFallback: {
+      trace: {
+        id: "unrelated-abort-trace",
+        timestamp: new Date().toISOString(),
+        name: "pi-agent",
+      },
+      observations: [],
+      observationById: new Map(),
+      attempted: false,
+    },
+  });
+  let calls = 0;
+  globalThis.fetch = (async () => {
+    calls += 1;
+    if (calls === 1) {
+      return new Response(null, { status: 404 });
+    }
+    throw new DOMException("Unrelated request cancellation", "AbortError");
+  }) as typeof fetch;
+  console.warn = (...args: unknown[]) => warnings.push(args);
+
+  try {
+    __setRuntimeForTest(runtime, 2_000);
+    await forceShutdownRuntime();
+
+    assert.equal(warnings.length, 1);
+    assert.match(String(warnings[0]?.[0]), /Failed to flush\/shutdown cleanly/);
+  } finally {
+    __setRuntimeForTest(null);
+    globalThis.fetch = originalFetch;
+    console.warn = originalWarn;
   }
 });
 


### PR DESCRIPTION
Closes #11

## What
- Treat only the `AbortError` whose identity is the shutdown controller's own `signal.reason` as expected deadline cancellation.
- Keep unrelated `AbortError`, network, ingestion, and cleanup failures on the existing `rememberRuntimeError()` + `console.warn()` path.
- Add real `forceShutdownRuntime()` regression coverage for both expected and unrelated `AbortError` cases.

## Why
When the bounded shutdown deadline aborts an in-flight REST fallback request, that rejection can win the `Promise.race()` in `withShutdownDeadline()`. The generic shutdown catch then reports a misleading `Failed to flush/shutdown cleanly` stack for normal best-effort timeout enforcement.

## Original failure
Observed with `pi-langfuse@1.5.9`, Node via Pi, and a self-hosted Langfuse instance started from the latest repository README instructions:

```text
📊 Langfuse: Failed to flush/shutdown cleanly DOMException [AbortError]: This operation was aborted
    at AbortController.abort (node:internal/abort_controller:506:18)
    at Timeout._onTimeout (.../pi-langfuse/src/langfuse.ts:652:54)
    ...
    at async traceExists (.../pi-langfuse/src/langfuse.ts:443:22)
    at async waitForTraceVisibility (.../pi-langfuse/src/langfuse.ts:469:9)
    at async fallbackToRestIngestion (.../pi-langfuse/src/langfuse.ts:493:7)
    at async withShutdownDeadline (.../pi-langfuse/src/langfuse.ts:156:12)
    at async shutdownRuntime (.../pi-langfuse/src/langfuse.ts:711:3)
```

## Reproduction
1. Start the self-hosted Langfuse dependency exactly as documented in the latest Langfuse README:
   ```bash
   git clone --depth=1 https://github.com/langfuse/langfuse.git
   cd langfuse
   docker compose up
   ```
2. Configure `pi-langfuse@1.5.9` to send to that local Langfuse instance, run Pi, produce a trace, and exit while `fallbackToRestIngestion()` is polling `GET /api/public/traces/:traceId`.
3. With the default `shutdownStepTimeoutMs` of 2 seconds, let the shutdown deadline fire while that request is in flight.
4. Observe the `Failed to flush/shutdown cleanly ... AbortError` warning and that the outer shutdown `catch` skips the remaining cleanup path.

The deterministic equivalent used by the regression test is a fallback trace plus a mocked `fetch` that never resolves and rejects with `init.signal.reason` when the shutdown signal aborts; `__setRuntimeForTest(runtime, 50)` followed by `forceShutdownRuntime()` reproduces the same race without credentials or a live service.

## How
Pass the shutdown controller signal only for the REST fallback deadline wrapper and classify the rejection by signal state, exact reason identity, `Error`, and `AbortError` name. The existing deadline, operation ordering, and best-effort telemetry semantics are unchanged; expected cancellation is debug-only.

## Validation
- `npm run typecheck`
- `npm test` (33 tests passed)

The Open Harness downstream workaround remains open until this fix is reviewed and released.