### PR TITLE
Make source metadata privacy-safe and opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,10 @@ export LANGFUSE_CAPTURE_OUTPUTS=true
 export LANGFUSE_CAPTURE_TOOL_IO=false
 export LANGFUSE_CAPTURE_SYSTEM_PROMPT=false
 export LANGFUSE_CAPTURE_CWD=false
+export LANGFUSE_CAPTURE_SOURCE_METADATA=false
 ```
+
+Source metadata remains off in every preset unless `LANGFUSE_CAPTURE_SOURCE_METADATA=true` is set explicitly.
 
 All captured payloads are redacted before upload. The extension masks common API keys, bearer tokens, passwords, cookies, private keys, Langfuse keys, GitHub/npm/AWS-style tokens, and local absolute paths.
 
@@ -198,50 +201,44 @@ The package also includes a Langfuse CLI skill, so Langfuse data can be queried 
 
 ## Source Metadata
 
-Local prototype note: source metadata support in this installed package is a local prototype patch. A durable solution should be shipped through an upstream PR, a fork, or a maintained package version so reinstalling the extension does not lose the behavior.
+Repository source capture is independent of the privacy presets and disabled by default. Enable it only after deciding that commit identity is appropriate for the Langfuse project:
 
-For Git-backed runs, the extension attaches safe source metadata to traces:
+```bash
+export LANGFUSE_CAPTURE_SOURCE_METADATA=true
+```
+
+For a Git worktree, the extension records only revision state:
 
 ```json
 {
   "source_type": "git-repo",
-  "repo_identity": "owner/repo",
-  "repo_owner": "owner",
-  "repo_name": "repo",
-  "repo_root_name": "repo",
-  "git_branch": "main",
-  "git_commit": "abc123",
-  "git_remote_host": "github.com",
-  "git_remote_path": "owner/repo",
+  "vcs.ref.head.revision": "0123456789abcdef...",
+  "git_detached": "false",
+  "git_dirty": "false",
   "metadata_source": "git-detection"
 }
 ```
 
-`repo_identity` is `owner/repo`. `repo_name` is the repo name only and must not contain a slash.
+The revision is the full `HEAD` commit. Dirty state includes tracked changes and untracked files, but never their paths or contents. Detached state is reported without a branch or tag name. Git remotes, URLs, credentials, usernames, branches, absolute paths, and repository names are never inspected or uploaded by this collector.
 
-A Git repo may optionally provide `.pi-langfuse.metadata.json`. Overrides are whitelist-only; unknown keys are ignored. Allowed keys are:
+When capture is off, the collector does not invoke Git and reports `source_type: "disabled"`. Non-Git directories report `non-git`; a missing or unusable Git executable and incomplete Git state report `unavailable`.
 
-```text
-repo_identity
-repo_owner
-repo_name
-source_type
-service_name
-project_slug
-environment
-observability_owner
+Use native Langfuse and OpenTelemetry settings for deployment identity and explicit operator-owned overrides instead of repository files:
+
+```bash
+export LANGFUSE_RELEASE="1.2.3"
+export LANGFUSE_TRACING_ENVIRONMENT="production"
+export OTEL_SERVICE_NAME="pi-agent"
+export OTEL_RESOURCE_ATTRIBUTES="service.version=1.2.3,vcs.repository.name=public-repo"
 ```
 
-Repo-local overrides are used only after the working directory is confirmed to be inside a usable Git repo. If Git detection fails for any reason, including a missing Git command, corrupted repo, or non-Git folder, the extension ignores repo-local identity files and emits only:
+`LANGFUSE_RELEASE` and `LANGFUSE_TRACING_ENVIRONMENT` keep their Langfuse semantics. `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` are loaded as process-scoped OpenTelemetry resource attributes; values such as `vcs.repository.name` apply to every session sharing the runtime, may identify private source, and require a runtime restart to change.
 
-```json
-{
-  "source_type": "non-git",
-  "metadata_source": "non-git"
-}
-```
+### Compatibility and rollback
 
-The extension must not upload raw absolute local paths, credentialed remotes, tokens, unknown override keys, or folder names for non-Git folders.
+Earlier versions emitted `git_commit`, branch, remote, owner, repository, and repo-local `.pi-langfuse.metadata.json` values by default. New traces use `vcs.ref.head.revision` and stop reading that file. Update dashboards before enabling source capture; historical traces are unchanged.
+
+Unset `LANGFUSE_CAPTURE_SOURCE_METADATA` to stop collection immediately. Pin `pi-langfuse@1.5.12` only if the old schema is required during migration; doing so also restores its broader default source disclosure.
 
 ## Troubleshooting
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -108,7 +108,10 @@ export LANGFUSE_CAPTURE_OUTPUTS=true
 export LANGFUSE_CAPTURE_TOOL_IO=false
 export LANGFUSE_CAPTURE_SYSTEM_PROMPT=false
 export LANGFUSE_CAPTURE_CWD=false
+export LANGFUSE_CAPTURE_SOURCE_METADATA=false
 ```
+
+所有隐私预设默认都关闭源码元数据；只有显式设置 `LANGFUSE_CAPTURE_SOURCE_METADATA=true` 才会启用。
 
 所有被采集的负载在上传前仍会脱敏。扩展会隐藏常见 API key、Bearer token、密码、Cookie、私钥、Langfuse key、GitHub/npm/AWS 风格 token，并对本地绝对路径做 hash。
 
@@ -174,6 +177,47 @@ pi list
 ```text
 /pi-langfuse-langfuse <查询内容>
 ```
+
+## 源码元数据
+
+仓库源码采集独立于隐私预设，默认关闭。只有在确认提交标识适合写入当前 Langfuse 项目后才启用：
+
+```bash
+export LANGFUSE_CAPTURE_SOURCE_METADATA=true
+```
+
+对于 Git 工作树，扩展只记录修订状态：
+
+```json
+{
+  "source_type": "git-repo",
+  "vcs.ref.head.revision": "0123456789abcdef...",
+  "git_detached": "false",
+  "git_dirty": "false",
+  "metadata_source": "git-detection"
+}
+```
+
+修订值为完整的 `HEAD` 提交。dirty 状态包含已跟踪变更和未跟踪文件，但绝不包含路径或内容。detached 状态不会附带分支名或标签名。此采集器不会检查或上传 Git remote、URL、凭据、用户名、分支、绝对路径或仓库名。
+
+关闭采集时，扩展不会调用 Git，并报告 `source_type: "disabled"`。非 Git 目录报告 `non-git`；Git 不可用或仓库状态不完整时报告 `unavailable`。
+
+部署标识和显式覆盖应使用 Langfuse 与 OpenTelemetry 原生配置，而不是仓库文件：
+
+```bash
+export LANGFUSE_RELEASE="1.2.3"
+export LANGFUSE_TRACING_ENVIRONMENT="production"
+export OTEL_SERVICE_NAME="pi-agent"
+export OTEL_RESOURCE_ATTRIBUTES="service.version=1.2.3,vcs.repository.name=public-repo"
+```
+
+`LANGFUSE_RELEASE` 与 `LANGFUSE_TRACING_ENVIRONMENT` 保持 Langfuse 原生语义。`OTEL_SERVICE_NAME` 和 `OTEL_RESOURCE_ATTRIBUTES` 会作为进程级 OpenTelemetry resource attributes 加载；`vcs.repository.name` 等值会应用到共享同一 runtime 的所有会话，可能暴露私有源码身份，而且修改后需要重启 runtime。
+
+### 兼容与回滚
+
+旧版本默认发送 `git_commit`、分支、remote、owner、仓库名及 `.pi-langfuse.metadata.json` 中的值。新 trace 改用 `vcs.ref.head.revision`，并停止读取该文件。启用源码采集前应更新 dashboard；历史 trace 不受影响。
+
+取消设置 `LANGFUSE_CAPTURE_SOURCE_METADATA` 可立即停止采集。迁移期间只有在必须保留旧 schema 时才固定到 `pi-langfuse@1.5.12`；这样也会恢复旧版本更宽泛的默认源码披露。
 
 ## 故障排除
 

--- a/src/capture-policy.ts
+++ b/src/capture-policy.ts
@@ -1,4 +1,4 @@
-import { redactValue } from "./redaction.js";
+import { hashPath, redactValue } from "./redaction.js";
 
 export interface CapturePolicy {
   readonly captureInputs: boolean;
@@ -6,6 +6,7 @@ export interface CapturePolicy {
   readonly captureToolIo: boolean;
   readonly captureSystemPrompt: boolean;
   readonly captureCwd: boolean;
+  readonly captureSourceMetadata: boolean;
 }
 
 export type PrivacyPreset = "metadata-only" | "prompts-only" | "conversations" | "full-debug";
@@ -36,6 +37,7 @@ const PRESETS: Record<PrivacyPreset, CapturePolicy> = {
     captureToolIo: false,
     captureSystemPrompt: false,
     captureCwd: false,
+    captureSourceMetadata: false,
   },
   "prompts-only": {
     captureInputs: true,
@@ -43,6 +45,7 @@ const PRESETS: Record<PrivacyPreset, CapturePolicy> = {
     captureToolIo: false,
     captureSystemPrompt: false,
     captureCwd: false,
+    captureSourceMetadata: false,
   },
   conversations: {
     captureInputs: true,
@@ -50,6 +53,7 @@ const PRESETS: Record<PrivacyPreset, CapturePolicy> = {
     captureToolIo: false,
     captureSystemPrompt: false,
     captureCwd: false,
+    captureSourceMetadata: false,
   },
   "full-debug": {
     captureInputs: true,
@@ -57,6 +61,7 @@ const PRESETS: Record<PrivacyPreset, CapturePolicy> = {
     captureToolIo: true,
     captureSystemPrompt: true,
     captureCwd: true,
+    captureSourceMetadata: false,
   },
 };
 
@@ -66,6 +71,7 @@ const FLAG_TO_FIELD = {
   LANGFUSE_CAPTURE_TOOL_IO: "captureToolIo",
   LANGFUSE_CAPTURE_SYSTEM_PROMPT: "captureSystemPrompt",
   LANGFUSE_CAPTURE_CWD: "captureCwd",
+  LANGFUSE_CAPTURE_SOURCE_METADATA: "captureSourceMetadata",
 } as const;
 
 function parseFlag(value: string | undefined): boolean | undefined {
@@ -105,7 +111,13 @@ function redactMetadata(metadata: Record<string, unknown> | undefined, policy: C
 
   const output: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(metadata)) {
-    if (key === "cwd" && !policy.captureCwd) {
+    if (key === "cwd") {
+      if (!policy.captureCwd) {
+        continue;
+      }
+      output[key] = typeof value === "string" && /^(?:\/|[A-Za-z]:[\\/]|\\\\)/.test(value)
+        ? hashPath(value)
+        : redactValue(value);
       continue;
     }
     output[key] = redactValue(value);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -75,7 +75,7 @@ function isPrivacyPreset(value: string | undefined): value is PrivacyPreset {
 }
 
 function inferPreset(policy: CapturePolicy): PrivacyPreset | "custom" {
-  const entries: Array<[PrivacyPreset, CapturePolicy]> = [
+  const entries: Array<[PrivacyPreset, Omit<CapturePolicy, "captureSourceMetadata">]> = [
     [
       "metadata-only",
       {
@@ -139,6 +139,7 @@ function describePolicy(policy: CapturePolicy) {
     `captureToolIo: ${policy.captureToolIo}`,
     `captureSystemPrompt: ${policy.captureSystemPrompt}`,
     `captureCwd: ${policy.captureCwd}`,
+    `captureSourceMetadata: ${policy.captureSourceMetadata}`,
   ].join("\n");
 }
 

--- a/src/handlers/agent.ts
+++ b/src/handlers/agent.ts
@@ -59,7 +59,8 @@ export async function startAgentRun(event: Record<string, unknown>, ctx: any) {
       images: event.images,
       context: event.context ?? event.attachments,
     });
-    const sourceMetadata = collectSourceMetadata(cwd);
+    const capturePolicy = getCapturePolicy();
+    const sourceMetadata = collectSourceMetadata(cwd, capturePolicy.captureSourceMetadata);
     const captured = applyCapturePolicy(
       {
         input: rawPromptInput,
@@ -71,7 +72,7 @@ export async function startAgentRun(event: Record<string, unknown>, ctx: any) {
           sessionId: state.currentSessionId || undefined,
         },
       },
-      getCapturePolicy(),
+      capturePolicy,
     );
 
     state.agentState = {

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -660,6 +660,7 @@ export async function getRuntime(): Promise<LangfuseRuntime> {
   if (!runtime) {
     const [
       { BasicTracerProvider },
+      { resources },
       { context },
       { AsyncHooksContextManager },
       { LangfuseSpanProcessor },
@@ -667,6 +668,7 @@ export async function getRuntime(): Promise<LangfuseRuntime> {
       { LangfuseClient },
     ] = await Promise.all([
       import("@opentelemetry/sdk-trace-base"),
+      import("@opentelemetry/sdk-node"),
       import("@opentelemetry/api"),
       import("@opentelemetry/context-async-hooks"),
       import("@langfuse/otel"),
@@ -692,7 +694,10 @@ export async function getRuntime(): Promise<LangfuseRuntime> {
         secretKey: state.config.secretKey,
         baseUrl: state.config.host,
       });
-      const tracerProvider = new BasicTracerProvider({ spanProcessors: [spanProcessor] });
+      const resource = resources.defaultResource().merge(
+        resources.detectResources({ detectors: [resources.envDetector] }),
+      );
+      const tracerProvider = new BasicTracerProvider({ resource, spanProcessors: [spanProcessor] });
       tracing.setLangfuseTracerProvider(tracerProvider);
 
       runtime = {

--- a/src/source-metadata.ts
+++ b/src/source-metadata.ts
@@ -1,160 +1,73 @@
-import { existsSync, readFileSync } from "node:fs";
-import { basename, dirname, join } from "node:path";
 import { execFileSync } from "node:child_process";
 
 export type SourceMetadata = Record<string, string>;
 
-const OVERRIDE_KEYS = new Set([
-  "repo_identity",
-  "repo_owner",
-  "repo_name",
-  "source_type",
-  "service_name",
-  "project_slug",
-  "environment",
-  "observability_owner",
-]);
+type GitResult =
+  | { status: "ok"; value: string }
+  | { status: "failed" }
+  | { status: "unavailable" };
 
-function nonGitMetadata(): SourceMetadata {
+function sourceStatus(status: "disabled" | "non-git" | "unavailable"): SourceMetadata {
   return {
-    source_type: "non-git",
-    metadata_source: "non-git",
+    source_type: status,
+    metadata_source: status,
   };
 }
 
-function runGit(cwd: string, args: string[]): string {
-  return execFileSync("git", args, {
-    cwd,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-    timeout: 2000,
-  }).trim();
-}
-
-function firstLine(value: string): string {
-  return value.split(/\r?\n/).map((line) => line.trim()).find(Boolean) ?? "";
-}
-
-export function sanitizeGitRemote(remoteUrl: string): Partial<Pick<SourceMetadata, "git_remote_host" | "git_remote_path">> {
-  const raw = firstLine(remoteUrl).replace(/\.git$/i, "");
-  if (!raw) {
-    return {};
-  }
-
+function runGit(cwd: string, args: string[], env: NodeJS.ProcessEnv): GitResult {
   try {
-    const parsed = new URL(raw);
-    const path = parsed.pathname.replace(/^\/+/, "").replace(/\.git$/i, "");
-    return parsed.hostname && path ? { git_remote_host: parsed.hostname, git_remote_path: path } : {};
-  } catch {
-    // Continue with scp-like SSH syntax, for example git@github.com:owner/repo.git.
-  }
-
-  const scpLike = raw.match(/^(?:[^@\s/:]+@)?([^:\s]+):(.+)$/);
-  if (scpLike) {
-    const host = scpLike[1];
-    const path = scpLike[2].replace(/^\/+/, "").replace(/\.git$/i, "");
-    return host && path && !path.includes("@") ? { git_remote_host: host, git_remote_path: path } : {};
-  }
-
-  return {};
-}
-
-function deriveIdentity(remotePath: string | undefined): Partial<Pick<SourceMetadata, "repo_identity" | "repo_owner" | "repo_name">> {
-  if (!remotePath) {
-    return {};
-  }
-  const parts = remotePath.split("/").filter(Boolean);
-  if (parts.length < 2) {
-    return {};
-  }
-  const repoName = parts[parts.length - 1];
-  const owner = parts[parts.length - 2];
-  if (!repoName || !owner || repoName.includes("/")) {
-    return {};
-  }
-  return {
-    repo_identity: `${owner}/${repoName}`,
-    repo_owner: owner,
-    repo_name: repoName,
-  };
-}
-
-function findRepoMetadataFile(cwd: string, gitRoot: string): string | undefined {
-  let current = cwd;
-  const root = gitRoot;
-  while (true) {
-    const candidate = join(current, ".pi-langfuse.metadata.json");
-    if (existsSync(candidate)) {
-      return candidate;
-    }
-    if (current === root) {
-      break;
-    }
-    const parent = dirname(current);
-    if (parent === current) {
-      break;
-    }
-    current = parent;
-  }
-  return undefined;
-}
-
-function readWhitelistedOverrides(cwd: string, gitRoot: string): SourceMetadata {
-  const path = findRepoMetadataFile(cwd, gitRoot);
-  if (!path) {
-    return {};
-  }
-  try {
-    const parsed = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
-    const output: SourceMetadata = {};
-    for (const [key, value] of Object.entries(parsed)) {
-      if (OVERRIDE_KEYS.has(key) && typeof value === "string" && value.trim()) {
-        output[key] = value.trim();
-      }
-    }
-    if (output.repo_name?.includes("/")) {
-      delete output.repo_name;
-    }
-    return output;
-  } catch {
-    return {};
-  }
-}
-
-export function collectSourceMetadata(cwd: string): SourceMetadata {
-  try {
-    const inside = runGit(cwd, ["rev-parse", "--is-inside-work-tree"]);
-    if (inside !== "true") {
-      return nonGitMetadata();
-    }
-
-    const gitRoot = runGit(cwd, ["rev-parse", "--show-toplevel"]);
-    const commit = runGit(cwd, ["rev-parse", "HEAD"]);
-    const branch = runGit(cwd, ["branch", "--show-current"]);
-    const remote = runGit(cwd, ["config", "--get", "remote.origin.url"]);
-    const remoteMetadata = sanitizeGitRemote(remote);
-    const derivedIdentity = deriveIdentity(remoteMetadata.git_remote_path);
-    const overrides = readWhitelistedOverrides(cwd, gitRoot);
-
-    const metadata: SourceMetadata = {
-      source_type: "git-repo",
-      repo_root_name: basename(gitRoot),
-      ...(branch ? { git_branch: branch } : {}),
-      git_commit: commit,
-      ...remoteMetadata,
-      ...derivedIdentity,
-      ...overrides,
-      metadata_source: Object.keys(overrides).length > 0 ? "repo-file" : "git-detection",
+    return {
+      status: "ok",
+      value: execFileSync("git", args, {
+        cwd,
+        encoding: "utf8",
+        env,
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 2000,
+      }).trim(),
     };
-
-    if (metadata.repo_name?.includes("/")) {
-      delete metadata.repo_name;
-    }
-    if (!metadata.repo_identity && metadata.repo_owner && metadata.repo_name) {
-      metadata.repo_identity = `${metadata.repo_owner}/${metadata.repo_name}`;
-    }
-    return metadata;
-  } catch {
-    return nonGitMetadata();
+  } catch (error) {
+    const failure = error as NodeJS.ErrnoException & { status?: number | null };
+    return typeof failure.status === "number"
+      ? { status: "failed" }
+      : { status: "unavailable" };
   }
+}
+
+export function collectSourceMetadata(
+  cwd: string,
+  enabled: boolean,
+  env: NodeJS.ProcessEnv = process.env,
+): SourceMetadata {
+  if (!enabled) {
+    return sourceStatus("disabled");
+  }
+
+  const inside = runGit(cwd, ["rev-parse", "--is-inside-work-tree"], env);
+  if (inside.status === "unavailable") {
+    return sourceStatus("unavailable");
+  }
+  if (inside.status !== "ok" || inside.value !== "true") {
+    return sourceStatus("non-git");
+  }
+
+  const revision = runGit(cwd, ["rev-parse", "--verify", "HEAD"], env);
+  const ref = runGit(cwd, ["symbolic-ref", "--quiet", "--short", "HEAD"], env);
+  const workingTree = runGit(cwd, ["status", "--porcelain=v1", "--untracked-files=normal"], env);
+  if (
+    revision.status !== "ok" ||
+    !/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i.test(revision.value) ||
+    workingTree.status !== "ok" ||
+    ref.status === "unavailable"
+  ) {
+    return sourceStatus("unavailable");
+  }
+
+  return {
+    source_type: "git-repo",
+    "vcs.ref.head.revision": revision.value,
+    git_detached: String(ref.status !== "ok"),
+    git_dirty: String(Boolean(workingTree.value)),
+    metadata_source: "git-detection",
+  };
 }

--- a/test/capture-policy.test.ts
+++ b/test/capture-policy.test.ts
@@ -12,7 +12,16 @@ test("defaults to full-debug capture to preserve existing trace detail", () => {
     captureToolIo: true,
     captureSystemPrompt: true,
     captureCwd: true,
+    captureSourceMetadata: false,
   });
+});
+
+test("source metadata stays disabled across privacy presets unless explicitly enabled", () => {
+  for (const preset of ["metadata-only", "prompts-only", "conversations", "full-debug"] as const) {
+    assert.equal(createCapturePolicy({ LANGFUSE_PRIVACY_PRESET: preset }).captureSourceMetadata, false);
+  }
+
+  assert.equal(createCapturePolicy({ LANGFUSE_CAPTURE_SOURCE_METADATA: "true" }).captureSourceMetadata, true);
 });
 
 test("metadata-only preset removes sensitive IO and cwd while keeping redacted metadata", () => {
@@ -42,6 +51,16 @@ test("metadata-only preset removes sensitive IO and cwd while keeping redacted m
     model: "gpt-5",
     authorization: "[REDACTED_SECRET]",
   });
+});
+
+test("full-debug hashes arbitrary absolute cwd values", () => {
+  const captured = applyCapturePolicy(
+    { metadata: { cwd: "/var/lib/private-repository" } },
+    createCapturePolicy({}),
+  );
+
+  assert.match(String(captured.metadata?.cwd), /^\[PATH_HASH:[a-f0-9]{12}\]$/);
+  assert.ok(!JSON.stringify(captured).includes("private-repository"));
 });
 
 test("fine-grained flags override privacy presets", () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -22,6 +22,7 @@ test("env privacy flags override saved config capture policy", () => {
   const config = loadConfigFromFile(configPath, {
     LANGFUSE_PRIVACY_PRESET: "metadata-only",
     LANGFUSE_CAPTURE_INPUTS: "true",
+    LANGFUSE_CAPTURE_SOURCE_METADATA: "true",
   });
 
   assert.deepEqual(config?.capturePolicy, {
@@ -30,6 +31,7 @@ test("env privacy flags override saved config capture policy", () => {
     captureToolIo: false,
     captureSystemPrompt: false,
     captureCwd: false,
+    captureSourceMetadata: true,
   });
 });
 

--- a/test/langfuse.test.ts
+++ b/test/langfuse.test.ts
@@ -353,6 +353,42 @@ test("runtime preserves the configured Langfuse OTel request timeout", async () 
   }
 });
 
+test("runtime reuses native OpenTelemetry resource environment overrides", async () => {
+  const previousServiceName = process.env.OTEL_SERVICE_NAME;
+  const previousResourceAttributes = process.env.OTEL_RESOURCE_ATTRIBUTES;
+  const previousConfig = state.config;
+
+  try {
+    process.env.OTEL_SERVICE_NAME = "pi-source-test";
+    process.env.OTEL_RESOURCE_ATTRIBUTES = "service.version=1.2.3,vcs.repository.name=public-repo";
+    state.config = {
+      publicKey: "pk_test",
+      secretKey: "sk_test",
+      host: "http://127.0.0.1:1",
+    };
+
+    const runtime = await getRuntime();
+    const attributes = (runtime.tracerProvider as any)._resource.attributes;
+
+    assert.equal(attributes["service.name"], "pi-source-test");
+    assert.equal(attributes["service.version"], "1.2.3");
+    assert.equal(attributes["vcs.repository.name"], "public-repo");
+  } finally {
+    await forceShutdownRuntime();
+    state.config = previousConfig;
+    if (previousServiceName === undefined) {
+      delete process.env.OTEL_SERVICE_NAME;
+    } else {
+      process.env.OTEL_SERVICE_NAME = previousServiceName;
+    }
+    if (previousResourceAttributes === undefined) {
+      delete process.env.OTEL_RESOURCE_ATTRIBUTES;
+    } else {
+      process.env.OTEL_RESOURCE_ATTRIBUTES = previousResourceAttributes;
+    }
+  }
+});
+
 test("buffered scores inherit the Langfuse tracing environment", async () => {
   const previousEnvironment = process.env.LANGFUSE_TRACING_ENVIRONMENT;
   const previousConfig = state.config;

--- a/test/source-metadata.test.ts
+++ b/test/source-metadata.test.ts
@@ -1,13 +1,23 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { chmodSync, mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
-import { collectSourceMetadata, sanitizeGitRemote } from "../src/source-metadata.js";
+import { createCapturePolicy } from "../src/capture-policy.js";
+import { startAgentRun } from "../src/handlers/agent.js";
+import { __setRuntimeForTest } from "../src/langfuse.js";
+import { collectSourceMetadata } from "../src/source-metadata.js";
+import { clearAllSessionStates, setCurrentSession, state } from "../src/state.js";
+import type { LangfuseObservation, LangfuseRuntime, ObservationUpdate } from "../src/types.js";
 
-function git(cwd: string, args: string[]) {
-  execFileSync("git", args, { cwd, stdio: "ignore" });
+function git(cwd: string, args: string[], capture = false): string {
+  const output = execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: capture ? ["ignore", "pipe", "ignore"] : "ignore",
+  });
+  return typeof output === "string" ? output.trim() : "";
 }
 
 function withTempDir(fn: (root: string) => void) {
@@ -20,97 +30,183 @@ function withTempDir(fn: (root: string) => void) {
 }
 
 function createRepo(root: string) {
-  const repo = join(root, "repo");
+  const repo = join(root, "private-client-alice");
   mkdirSync(repo);
   git(repo, ["init"]);
-  git(repo, ["config", "user.email", "test@example.com"]);
-  git(repo, ["config", "user.name", "Test User"]);
+  git(repo, ["config", "user.email", "alice@example.com"]);
+  git(repo, ["config", "user.name", "Alice Example"]);
   writeFileSync(join(repo, "README.md"), "test\n");
   git(repo, ["add", "README.md"]);
   git(repo, ["commit", "-m", "init"]);
+  git(repo, ["checkout", "-b", "alice/private-ticket"]);
+  git(repo, ["remote", "add", "origin", "https://alice:token@private.example.com/acme/private-client-alice.git"]);
   return repo;
 }
 
-test("collectSourceMetadata applies whitelist overrides in valid Git repos", () => {
+test("collectSourceMetadata emits only opt-in revision state for Git repos", () => {
   withTempDir((root) => {
     const repo = createRepo(root);
-    git(repo, ["remote", "add", "origin", "https://token:secret@github.com/zyahav/Google-Calendar.git"]);
     writeFileSync(
       join(repo, ".pi-langfuse.metadata.json"),
-      JSON.stringify(
-        {
-          repo_identity: "zyahav/Google-Calendar",
-          repo_owner: "zyahav",
-          repo_name: "Google-Calendar",
-          source_type: "git-repo",
-          service_name: "calendar-supervisor",
-          raw_path: "/Users/private/project",
-          token: "secret-token",
-          unknown_key: "must-not-pass",
-          git_remote_path: "evil/override",
-        },
-        null,
-        2,
-      ),
+      JSON.stringify({
+        repo_identity: "acme/private-client-alice",
+        repo_owner: "alice",
+        repo_name: "private-client-alice",
+        environment: "private-production",
+      }),
     );
 
-    const metadata = collectSourceMetadata(repo);
-    assert.equal(metadata.repo_identity, "zyahav/Google-Calendar");
-    assert.equal(metadata.repo_owner, "zyahav");
-    assert.equal(metadata.repo_name, "Google-Calendar");
-    assert.equal(metadata.service_name, "calendar-supervisor");
-    assert.equal(metadata.source_type, "git-repo");
-    assert.equal(metadata.git_remote_host, "github.com");
-    assert.equal(metadata.git_remote_path, "zyahav/Google-Calendar");
-    assert.ok(!metadata.repo_name.includes("/"));
-    assert.ok(!("raw_path" in metadata));
-    assert.ok(!("token" in metadata));
-    assert.ok(!("unknown_key" in metadata));
+    const metadata = collectSourceMetadata(repo, true);
+    assert.deepEqual(metadata, {
+      source_type: "git-repo",
+      "vcs.ref.head.revision": git(repo, ["rev-parse", "HEAD"], true),
+      git_detached: "false",
+      git_dirty: "true",
+      metadata_source: "git-detection",
+    });
+
+    const serialized = JSON.stringify(metadata);
+    for (const sensitive of [
+      repo,
+      "private-client-alice",
+      "alice",
+      "private.example.com",
+      "acme",
+      "token",
+      "alice/private-ticket",
+      "https://",
+    ]) {
+      assert.ok(!serialized.includes(sensitive), `must not expose ${sensitive}`);
+    }
   });
 });
 
-test("sanitizeGitRemote strips credentials, protocols, and git suffixes", () => {
-  for (const remote of [
-    "https://token:secret@github.com/zyahav/Google-Calendar.git",
-    "git@github.com:zyahav/Google-Calendar.git",
-    "https://github.com/zyahav/Google-Calendar.git",
-  ]) {
-    const sanitized = sanitizeGitRemote(remote);
-    const serialized = JSON.stringify(sanitized);
-    assert.equal(sanitized.git_remote_host, "github.com");
-    assert.equal(sanitized.git_remote_path, "zyahav/Google-Calendar");
-    assert.ok(!serialized.includes("token"));
-    assert.ok(!serialized.includes("secret"));
-    assert.ok(!serialized.includes("https://"));
-    assert.ok(!serialized.includes("git@"));
-    assert.ok(!serialized.includes(".git"));
+test("collectSourceMetadata distinguishes clean, dirty, and detached Git state", () => {
+  withTempDir((root) => {
+    const repo = createRepo(root);
+    git(repo, ["clean", "-fd"]);
+
+    const clean = collectSourceMetadata(repo, true);
+    assert.equal(clean.git_dirty, "false");
+    assert.equal(clean.git_detached, "false");
+
+    writeFileSync(join(repo, "untracked-private-name.txt"), "private\n");
+    const dirty = collectSourceMetadata(repo, true);
+    assert.equal(dirty.git_dirty, "true");
+    assert.ok(!JSON.stringify(dirty).includes("untracked-private-name"));
+
+    git(repo, ["checkout", "--detach"]);
+    const detached = collectSourceMetadata(repo, true);
+    assert.equal(detached.git_detached, "true");
+    assert.equal(detached["vcs.ref.head.revision"], git(repo, ["rev-parse", "HEAD"], true));
+  });
+});
+
+test("collectSourceMetadata rejects non-object revision output", () => {
+  withTempDir((root) => {
+    const repo = createRepo(root);
+    const fakeBin = join(root, "bin");
+    const fakeGit = join(fakeBin, "git");
+    mkdirSync(fakeBin);
+    writeFileSync(
+      fakeGit,
+      [
+        "#!/bin/sh",
+        "case \"$*\" in",
+        "  *--is-inside-work-tree*) echo true ;;",
+        "  *--verify*) echo https://private.example.test/credential ;;",
+        "  *) exit 0 ;;",
+        "esac",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(fakeGit, 0o700);
+
+    assert.deepEqual(collectSourceMetadata(repo, true, { PATH: fakeBin }), {
+      source_type: "unavailable",
+      metadata_source: "unavailable",
+    });
+  });
+});
+
+test("collectSourceMetadata reports disabled without invoking Git", () => {
+  const metadata = collectSourceMetadata("/path/that/does/not/exist", false, { PATH: "" });
+  assert.deepEqual(metadata, {
+    source_type: "disabled",
+    metadata_source: "disabled",
+  });
+});
+
+test("startAgentRun keeps source metadata disabled by default", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-langfuse-source-agent-"));
+  const previousConfig = state.config;
+  let observedMetadata: Record<string, unknown> | undefined;
+  const observation: LangfuseObservation = {
+    traceId: "trace-test",
+    update: () => observation,
+    end: () => {},
+    setTraceIO: () => {},
+  };
+  const runtime = {
+    startObservation: (_name: string, body?: ObservationUpdate) => {
+      observedMetadata = body?.metadata;
+      return observation;
+    },
+    propagateAttributes: (_params: unknown, fn: () => LangfuseObservation) => fn(),
+    scoreClient: {},
+  } satisfies LangfuseRuntime;
+
+  try {
+    const repo = createRepo(root);
+    clearAllSessionStates();
+    setCurrentSession("source-policy-test");
+    state.config = {
+      publicKey: "pk-test",
+      secretKey: ["test", "value"].join("-"),
+      host: "https://example.test",
+      capturePolicy: createCapturePolicy({}),
+    };
+    __setRuntimeForTest(runtime);
+
+    await startAgentRun({ prompt: "test", systemPromptOptions: { cwd: repo } }, {});
+
+    assert.equal(observedMetadata?.source_type, "disabled");
+    assert.equal(observedMetadata?.metadata_source, "disabled");
+    assert.equal(observedMetadata?.["vcs.ref.head.revision"], undefined);
+    assert.match(String(observedMetadata?.cwd), /^\[PATH_HASH:[a-f0-9]{12}\]$/);
+    assert.ok(!JSON.stringify(observedMetadata).includes("private-client-alice"));
+  } finally {
+    __setRuntimeForTest(null);
+    state.config = previousConfig;
+    clearAllSessionStates();
+    rmSync(root, { recursive: true, force: true });
   }
 });
 
-test("collectSourceMetadata keeps repo_name repo-only", () => {
+test("collectSourceMetadata distinguishes non-Git and unavailable Git", () => {
   withTempDir((root) => {
-    const repo = createRepo(root);
-    git(repo, ["remote", "add", "origin", "https://github.com/zyahav/Google-Calendar.git"]);
-    const metadata = collectSourceMetadata(repo);
-    assert.equal(metadata.repo_identity, "zyahav/Google-Calendar");
-    assert.equal(metadata.repo_owner, "zyahav");
-    assert.equal(metadata.repo_name, "Google-Calendar");
-    assert.ok(!metadata.repo_name.includes("/"));
-  });
-});
-
-test("collectSourceMetadata isolates non-Git folders even with metadata files", () => {
-  withTempDir((root) => {
-    const nonGit = join(root, "non-git");
+    const nonGit = join(root, "private-non-git-folder");
     mkdirSync(nonGit);
-    assert.deepEqual(Object.keys(collectSourceMetadata(nonGit)).sort(), ["metadata_source", "source_type"]);
     writeFileSync(
       join(nonGit, ".pi-langfuse.metadata.json"),
-      JSON.stringify({ repo_identity: "should/not-pass", repo_owner: "should", repo_name: "not-pass" }),
+      JSON.stringify({ repo_identity: "should/not-pass", repo_owner: "alice", repo_name: "private" }),
     );
-    const nonGitWithFile = collectSourceMetadata(nonGit);
-    assert.deepEqual(Object.keys(nonGitWithFile).sort(), ["metadata_source", "source_type"]);
-    assert.equal(nonGitWithFile.source_type, "non-git");
-    assert.equal(nonGitWithFile.metadata_source, "non-git");
+
+    assert.deepEqual(collectSourceMetadata(nonGit, true), {
+      source_type: "non-git",
+      metadata_source: "non-git",
+    });
+    assert.deepEqual(collectSourceMetadata(nonGit, true, { PATH: "" }), {
+      source_type: "unavailable",
+      metadata_source: "unavailable",
+    });
+
+    const fakeBin = join(root, "unusable-bin");
+    mkdirSync(fakeBin);
+    writeFileSync(join(fakeBin, "git"), "not executable\n");
+    assert.deepEqual(collectSourceMetadata(nonGit, true, { PATH: fakeBin }), {
+      source_type: "unavailable",
+      metadata_source: "unavailable",
+    });
   });
 });

--- a/types/langfuse-runtime-shims.d.ts
+++ b/types/langfuse-runtime-shims.d.ts
@@ -1,6 +1,6 @@
 declare module "@opentelemetry/sdk-trace-base" {
   export class BasicTracerProvider {
-    constructor(options?: { spanProcessors?: unknown[] });
+    constructor(options?: { resource?: unknown; spanProcessors?: unknown[] });
     forceFlush?(): Promise<void>;
     shutdown?(): Promise<void>;
   }


### PR DESCRIPTION
## Summary

- make repository source metadata an explicit opt-in
- emit only full Git revision, detached state, and dirty state without reading repository names, branches, remotes, URLs, credentials, or local metadata files
- load operator-provided `service.*` and `vcs.*` values through native OpenTelemetry resource environment settings

## Motivation

Source metadata in 1.5.12 is enabled by default and can expose private repository identity through root, branch, remote, owner, and repository fields. Source provenance should fail closed while still supporting bounded commit and working-tree state when an operator explicitly enables it.

## Compatibility

`LANGFUSE_CAPTURE_SOURCE_METADATA` defaults to false independently of privacy presets. Opted-in traces replace `git_commit` with `vcs.ref.head.revision`, add `git_detached` and `git_dirty`, and stop reading `.pi-langfuse.metadata.json`. Historical traces remain unchanged.

Deployments should migrate dashboards before enabling source capture. Unset `LANGFUSE_CAPTURE_SOURCE_METADATA` for immediate rollback, or pin 1.5.12 if the old schema is temporarily required; pinning also restores its broader default disclosure.

`LANGFUSE_RELEASE` and `LANGFUSE_TRACING_ENVIRONMENT` keep native Langfuse behavior. `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` remain process-scoped OpenTelemetry settings shared by sessions using the same runtime.

## Testing

- `npm run typecheck`
- `npm test` (76 tests)
- `npm pack --dry-run`

## Development disclosure

This PR was developed with assistance from AI tooling. I reviewed it in full and take responsibility for the contribution.
