### PR TITLE
fix: report cache and reasoning tokens as proper usage buckets

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -369,6 +369,24 @@ export function getMessageFromEvent(event: Record<string, unknown>): Record<stri
   return undefined;
 }
 
+/**
+ * Langfuse buckets usage and cost details by substring match on the key name:
+ * `input` rolls up into the Input row of the breakdown, `output` into Output,
+ * and anything matching neither falls into the catch-all Other row. Camel-cased
+ * `cacheWrite` lands in Other, so cache is reported outside the Input bucket it
+ * belongs to and never reaches Langfuse's own price table, which resolves
+ * usage types by exact key match (`price.usageType === key`) and therefore
+ * cannot price cache for providers that do not report cost themselves.
+ *
+ * These are the key names Langfuse documents for Anthropic-style caching.
+ * Pi reports `input` exclusive of cached tokens, so the buckets stay
+ * non-overlapping and nothing is double counted. Emitting both spellings would
+ * be worse than either: the canonical key would be counted in Input and the
+ * camel-cased duplicate again in Other.
+ */
+const CACHE_READ_KEY = "cache_read_input_tokens";
+const CACHE_WRITE_KEY = "cache_creation_input_tokens";
+
 export function extractUsage(messageOrEvent: Record<string, unknown>): Record<string, number> | undefined {
   const usage = (messageOrEvent.usage ??
     (messageOrEvent.message && typeof messageOrEvent.message === "object"
@@ -388,8 +406,8 @@ export function extractUsage(messageOrEvent: Record<string, unknown>): Record<st
     input,
     output,
     total,
-    ...(cacheRead ? { cacheRead } : {}),
-    ...(cacheWrite ? { cacheWrite } : {}),
+    ...(cacheRead ? { [CACHE_READ_KEY]: cacheRead } : {}),
+    ...(cacheWrite ? { [CACHE_WRITE_KEY]: cacheWrite } : {}),
   };
 }
 
@@ -405,12 +423,20 @@ export function extractCostDetails(messageOrEvent: Record<string, unknown>): Rec
 
   const input = Number(cost.input ?? cost.inputCost ?? 0);
   const output = Number(cost.output ?? cost.outputCost ?? 0);
-  const total = Number(cost.total ?? cost.totalCost ?? input + output);
-  if (input === 0 && output === 0 && total === 0) {
+  const cacheRead = Number(cost.cacheRead ?? cost.cache_read ?? 0);
+  const cacheWrite = Number(cost.cacheWrite ?? cost.cache_write ?? 0);
+  const total = Number(cost.total ?? cost.totalCost ?? input + output + cacheRead + cacheWrite);
+  if (input === 0 && output === 0 && cacheRead === 0 && cacheWrite === 0 && total === 0) {
     return undefined;
   }
 
-  return { input, output, total };
+  return {
+    input,
+    output,
+    total,
+    ...(cacheRead ? { [CACHE_READ_KEY]: cacheRead } : {}),
+    ...(cacheWrite ? { [CACHE_WRITE_KEY]: cacheWrite } : {}),
+  };
 }
 
 export function extractResponseMetadata(event: Record<string, unknown>): Record<string, unknown> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -387,6 +387,40 @@ export function getMessageFromEvent(event: Record<string, unknown>): Record<stri
 const CACHE_READ_KEY = "cache_read_input_tokens";
 const CACHE_WRITE_KEY = "cache_creation_input_tokens";
 
+/**
+ * Anthropic prices one-hour cache writes at a different rate from the default
+ * five-minute ones, and Langfuse mirrors that with two TTL-specific usage keys.
+ * Pi reports the total under `cacheWrite` and the hour-TTL share of it under
+ * `cacheWrite1h`, so the two Langfuse buckets are `cacheWrite - cacheWrite1h`
+ * and `cacheWrite1h`. Both keys contain `input`, so the Input row of the
+ * breakdown is unchanged; only the price lookup differs.
+ */
+const CACHE_WRITE_5M_KEY = "input_cache_creation_5m";
+const CACHE_WRITE_1H_KEY = "input_cache_creation_1h";
+
+/**
+ * Pi emits `cacheWrite1h: 0` on every Anthropic-family response, so a zero
+ * carries no TTL information. Only a non-zero hour-TTL figure is a real
+ * breakdown; everything else stays on the TTL-agnostic key so dashboards and
+ * custom model prices keyed on it keep working.
+ */
+function splitCacheWrite(cacheWrite: number, cacheWrite1h: number): Record<string, number> {
+  if (!cacheWrite) {
+    return {};
+  }
+
+  const longWrite = Math.min(Math.max(cacheWrite1h, 0), cacheWrite);
+  if (!longWrite) {
+    return { [CACHE_WRITE_KEY]: cacheWrite };
+  }
+
+  const shortWrite = cacheWrite - longWrite;
+  return {
+    ...(shortWrite ? { [CACHE_WRITE_5M_KEY]: shortWrite } : {}),
+    [CACHE_WRITE_1H_KEY]: longWrite,
+  };
+}
+
 export function extractUsage(messageOrEvent: Record<string, unknown>): Record<string, number> | undefined {
   const usage = (messageOrEvent.usage ??
     (messageOrEvent.message && typeof messageOrEvent.message === "object"
@@ -401,13 +435,14 @@ export function extractUsage(messageOrEvent: Record<string, unknown>): Record<st
   const total = Number(usage.total ?? usage.totalTokens ?? usage.total_tokens ?? input + output);
   const cacheRead = Number(usage.cacheRead ?? usage.cache_read ?? usage.cachedTokens ?? 0);
   const cacheWrite = Number(usage.cacheWrite ?? usage.cache_write ?? 0);
+  const cacheWrite1h = Number(usage.cacheWrite1h ?? usage.cache_write_1h ?? 0);
 
   return {
     input,
     output,
     total,
     ...(cacheRead ? { [CACHE_READ_KEY]: cacheRead } : {}),
-    ...(cacheWrite ? { [CACHE_WRITE_KEY]: cacheWrite } : {}),
+    ...splitCacheWrite(cacheWrite, cacheWrite1h),
   };
 }
 
@@ -424,6 +459,9 @@ export function extractCostDetails(messageOrEvent: Record<string, unknown>): Rec
   const input = Number(cost.input ?? cost.inputCost ?? 0);
   const output = Number(cost.output ?? cost.outputCost ?? 0);
   const cacheRead = Number(cost.cacheRead ?? cost.cache_read ?? 0);
+  // Pi has no per-TTL cost figure: `cost.cacheWrite` already prices the
+  // five-minute and one-hour shares at their own rates and sums them, so the
+  // cost side stays on the aggregate key even when usage is split by TTL.
   const cacheWrite = Number(cost.cacheWrite ?? cost.cache_write ?? 0);
   const total = Number(cost.total ?? cost.totalCost ?? input + output + cacheRead + cacheWrite);
   if (input === 0 && output === 0 && cacheRead === 0 && cacheWrite === 0 && total === 0) {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 
 import {
   extractAssistantOutput,
+  extractCostDetails,
+  extractUsage,
   extractModelParameters,
   normalizeContentForLangfuse,
   shapePayload,
@@ -162,4 +164,66 @@ test("extractAssistantOutput redacts toolCall arguments before stringifying Open
   assert.deepEqual(JSON.parse(output.tool_calls[0]?.function.arguments ?? ""), {
     password: "[REDACTED_SECRET]",
   });
+});
+
+test("extractUsage reports cache tokens under keys Langfuse buckets as input", () => {
+  const usage = extractUsage({
+    usage: { input: 2, output: 2546, cacheRead: 0, cacheWrite: 118208, totalTokens: 120756 },
+  });
+
+  assert.deepEqual(usage, {
+    input: 2,
+    output: 2546,
+    total: 120756,
+    cache_creation_input_tokens: 118208,
+  });
+
+  const bucketed = Object.entries(usage ?? {})
+    .filter(([key]) => key !== "total")
+    .reduce((sum, [, value]) => sum + value, 0);
+  assert.equal(bucketed, usage?.total);
+});
+
+test("extractCostDetails keeps cache cost so the breakdown adds up to total", () => {
+  const cost = extractCostDetails({
+    usage: {
+      cost: { input: 0.00001, output: 0.06365, cacheRead: 0, cacheWrite: 0.7388, total: 0.80246 },
+    },
+  });
+
+  assert.deepEqual(cost, {
+    input: 0.00001,
+    output: 0.06365,
+    total: 0.80246,
+    cache_creation_input_tokens: 0.7388,
+  });
+
+  const bucketed = Object.entries(cost ?? {})
+    .filter(([key]) => key !== "total")
+    .reduce((sum, [, value]) => sum + value, 0);
+  assert.equal(Number(bucketed.toFixed(10)), cost?.total);
+});
+
+test("extractCostDetails reports cache reads alongside input and output", () => {
+  const cost = extractCostDetails({
+    usage: {
+      cost: { input: 0.00001, output: 0.019725, cacheRead: 0.010993, cacheWrite: 0.00086875, total: 0.03159675 },
+    },
+  });
+
+  assert.equal(cost?.cache_read_input_tokens, 0.010993);
+  assert.equal(cost?.cache_creation_input_tokens, 0.00086875);
+});
+
+test("extractCostDetails still discards all-zero cost payloads so model pricing applies", () => {
+  assert.equal(
+    extractCostDetails({ usage: { cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } } }),
+    undefined,
+  );
+});
+
+test("extractCostDetails derives total from cache-only cost data", () => {
+  const cost = extractCostDetails({ usage: { cost: { cacheRead: 0.25, cacheWrite: 0.75 } } });
+
+  assert.equal(cost?.total, 1);
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -184,6 +184,82 @@ test("extractUsage reports cache tokens under keys Langfuse buckets as input", (
   assert.equal(bucketed, usage?.total);
 });
 
+test("extractUsage keeps the TTL-agnostic cache write key when no hour-TTL share is reported", () => {
+  // Pi emits cacheWrite1h: 0 on every Anthropic response that used the default TTL.
+  const usage = extractUsage({
+    usage: { input: 2, output: 2546, cacheRead: 0, cacheWrite: 118208, cacheWrite1h: 0, totalTokens: 120756 },
+  });
+
+  assert.deepEqual(usage, {
+    input: 2,
+    output: 2546,
+    total: 120756,
+    cache_creation_input_tokens: 118208,
+  });
+});
+
+test("extractUsage splits cache writes by TTL when an hour-TTL share is reported", () => {
+  // Pi reports cacheWrite1h as a subset of cacheWrite, not alongside it.
+  const usage = extractUsage({
+    usage: { input: 2, output: 2546, cacheRead: 0, cacheWrite: 118208, cacheWrite1h: 18208, totalTokens: 120756 },
+  });
+
+  assert.deepEqual(usage, {
+    input: 2,
+    output: 2546,
+    total: 120756,
+    input_cache_creation_5m: 100000,
+    input_cache_creation_1h: 18208,
+  });
+
+  const bucketed = Object.entries(usage ?? {})
+    .filter(([key]) => key !== "total")
+    .reduce((sum, [, value]) => sum + value, 0);
+  assert.equal(bucketed, usage?.total);
+
+  // Langfuse sums every key containing "input" into the Input row, so the split
+  // must not change what that row reports.
+  const inputRow = Object.entries(usage ?? {})
+    .filter(([key]) => key.includes("input"))
+    .reduce((sum, [, value]) => sum + value, 0);
+  assert.equal(inputRow, 118210);
+});
+
+test("extractUsage reports only the hour-TTL bucket when every cache write used the long TTL", () => {
+  const usage = extractUsage({
+    usage: { input: 10, output: 20, cacheWrite: 5000, cacheWrite1h: 5000, totalTokens: 5030 },
+  });
+
+  assert.deepEqual(usage, { input: 10, output: 20, total: 5030, input_cache_creation_1h: 5000 });
+});
+
+test("extractUsage clamps an hour-TTL share that exceeds the reported cache write total", () => {
+  const usage = extractUsage({
+    usage: { input: 10, output: 20, cacheWrite: 100, cacheWrite1h: 150, totalTokens: 130 },
+  });
+
+  assert.deepEqual(usage, { input: 10, output: 20, total: 130, input_cache_creation_1h: 100 });
+});
+
+test("extractCostDetails keeps cache write cost on the aggregate key when usage is split by TTL", () => {
+  // Pi prices the five-minute and one-hour shares at their own rates and reports
+  // only the sum, so there is no per-TTL cost figure to split.
+  const cost = extractCostDetails({
+    usage: {
+      cacheWrite: 118208,
+      cacheWrite1h: 18208,
+      cost: { input: 0.00001, output: 0.06365, cacheRead: 0, cacheWrite: 0.484248, total: 0.547908 },
+    },
+  });
+
+  assert.deepEqual(cost, {
+    input: 0.00001,
+    output: 0.06365,
+    total: 0.547908,
+    cache_creation_input_tokens: 0.484248,
+  });
+});
+
 test("extractCostDetails keeps cache cost so the breakdown adds up to total", () => {
   const cost = extractCostDetails({
     usage: {


### PR DESCRIPTION
Fixes #19. Fixes #23.

On providers that bill prompt caching as separate line items, the Langfuse cost popover did not reconcile: `Input cost + Output cost` was a fraction of `Total cost`. On Anthropic that hid 92% of the bill ($0.73880 of $0.80246 on the generation in the issue). Token counts had the same problem — `2 prompt → 2,546 completion (Σ 120,756)`.

## Cause

Two spots in `src/utils.ts`:

- `extractCostDetails()` returned `{ input, output, total }`, silently dropping `cost.cacheRead` / `cost.cacheWrite`. `total` still carried those dollars, so nothing accounted for the difference.
- `extractUsage()` did forward cache tokens, but under `cacheRead` / `cacheWrite`. Langfuse buckets details by substring match on the key name, so camelCase cache keys fall into the catch-all Other row instead of Input — and, more importantly, never match the price table, which resolves usage types by exact key (`price.usageType === key` in `IngestionService.calculateUsageCosts`).

## Change

### Commit 1 — cache keys (#19)

Both functions now emit `cache_read_input_tokens` / `cache_creation_input_tokens` — the names Langfuse uses for Anthropic-style caching — via shared constants.

Two smaller fixes that fall out of it:

- The `total` fallback is now `input + output + cacheRead + cacheWrite`, so a payload carrying only cache costs gets a correct derived total instead of one that omits every component it has.
- The zeroed-cost guard from #3 now also requires the cache figures to be zero. Z.ai's all-zero payloads are still discarded so model pricing applies, but a genuine cache-only cost is no longer thrown away as "no cost data".

### Commit 2 — TTL split (#23)

Per review: `cacheWrite1h` is confirmed to be a subset of `cacheWrite`. In Pi's `anthropic-messages` provider:

```js
output.usage.cacheWrite   = usage.cache_creation_input_tokens || 0
output.usage.cacheWrite1h = usage.cache_creation?.ephemeral_1h_input_tokens || 0
output.usage.totalTokens  = input + output + cacheRead + cacheWrite   // no separate 1h term
```

and `calculateCost` already prices the two shares separately before summing into `cost.cacheWrite`:

```js
let longWrite = usage.cacheWrite1h ?? 0, shortWrite = usage.cacheWrite - longWrite;
usage.cost.cacheWrite = (rates.cacheWrite * shortWrite + rates.input * 2 * longWrite) / 1e6;
```

`extractUsage` now reads `cacheWrite1h` and, when it is non-zero, emits `input_cache_creation_5m = cacheWrite - cacheWrite1h` and `input_cache_creation_1h = cacheWrite1h` — the keys Langfuse's price table carries for Claude (`input_cache_creation_1h` is priced at 2× input there, matching Pi's formula). Otherwise it keeps `cache_creation_input_tokens`.

**Why "non-zero" rather than "field present":** Pi sets `cacheWrite1h: 0` on every Anthropic-family response that used the default 5-minute TTL (16,350 of my local records carry the field; all are zero). A zero therefore carries no TTL information. Splitting on mere presence would move every Anthropic generation onto `input_cache_creation_5m` and make `cache_creation_input_tokens` effectively never appear — breaking any dashboard or custom model price keyed on it for no gain. With the non-zero rule the aggregate key stays stable for the common case, and the split only appears on generations that actually used hour-long caching. Both TTL keys contain `input`, so the Input row of the breakdown is unchanged either way.

The 1h share is clamped to `cacheWrite`, so an inconsistent provider count cannot drive the 5m bucket negative.

Cost stays on the aggregate key: Pi has no per-TTL cost figure, and `cost.cacheWrite` already applies the correct TTL-specific rates.

## Correctness

Pi reports `input` *exclusive* of cached tokens (`input: 2` next to `cacheWrite: 118208`), so the buckets are disjoint and this does not reproduce the double-counting of langfuse/langfuse#9386. After the change the generation from the issue reads Input $0.73881 + Output $0.06365 = Total $0.80246, and `118,210 prompt → 2,546 completion (Σ 120,756)`.

## Tests

10 new cases in `test/utils.test.ts`, built on captured Pi session payloads — cache-write-heavy and cache-read-heavy shapes, each asserting the non-total buckets sum to `total`, regression cover for the all-zero guard and the derived-total path, and the TTL split: unsplit key when `cacheWrite1h` is zero, 5m/1h split with the Input row unchanged, 1h-only when every write used the long TTL, clamp on inconsistent counts, and cost staying on the aggregate key. `npm test` 90/90, `npm run typecheck` clean.

## Verified against a live instance

The cache-key change is running against a self-hosted v4.27.0 in `events_only` mode. On an Anthropic generation the cost popover reads Input $0.73881 + Output $0.06365 = Total $0.80246, matching Pi's own numbers exactly.

Also checked on an OpenAI-shaped provider, since that is the family langfuse/langfuse#9386 is about. On `z-ai/glm-5.3-flash` via OpenRouter, Pi reports `input: 96, cacheRead: 14720, output: 37` against `totalTokens: 14853` — that is `96 + 14720 + 37`, so Pi has already converted OpenAI's inclusive `prompt_tokens` into exclusive buckets. Langfuse renders Input usage 14,816 with the split beneath it. No double counting on either provider family.

I have not run a live 1h-TTL session (I have never enabled hour-long caching), so the TTL split is covered by unit tests against Pi's documented shape rather than a live trace.

## Reasoning tokens

Moved out of this PR per review; it will follow separately with reasoning clamped to the reported `output` so the buckets always sum to `total`.

## Compatibility note

This renames two keys in the emitted `usageDetails`. They are undocumented — no mention in the README — but anyone who built a dashboard against `cacheRead` / `cacheWrite` will need to repoint it, so it is worth a line in the release notes.
