### PR TITLE
fix: keep child observations inside their Langfuse session

### DIFF
--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -458,6 +458,32 @@ function observationType(asType?: string): FallbackObservationType {
   return asType === "generation" ? "GENERATION" : "SPAN";
 }
 
+/**
+ * Langfuse stamps propagated attributes onto a span in
+ * `LangfuseSpanProcessor.onStart(span, parentContext)`, reading them from the
+ * OTel context that was active when the span was created. `propagateAttributes`
+ * only seeds that context for the duration of its callback, so a child created
+ * later — from a separate event handler, outside the callback — is written with
+ * an empty `session.id`.
+ *
+ * That is invisible in the legacy data model, where the session lives on the
+ * trace, but Langfuse v4 stores `session_id` per event row and aggregates a
+ * session with `WHERE session_id != ''`. Unstamped children drop out of
+ * `sumMap(cost_details)` and `sumMap(usage_details)`, which is why such
+ * sessions report their trace count correctly but no cost and no usage at all.
+ *
+ * Re-entering the propagated context for every child keeps the whole tree in
+ * the session. The id is read back off the parent span rather than from
+ * `state.currentSessionId`, so a child created outside an active session scope
+ * still inherits whatever its parent was actually stamped with.
+ */
+const OTEL_SESSION_ID_ATTRIBUTE = "session.id";
+
+function readSessionId(observation: any): string | undefined {
+  const value = observation?.otelSpan?.attributes?.[OTEL_SESSION_ID_ATTRIBUTE];
+  return typeof value === "string" && value ? value : undefined;
+}
+
 function wrapObservation(
   observation: any,
   store: RestFallbackStore,
@@ -517,7 +543,12 @@ function wrapObservation(
       return observation.end();
     },
     startObservation(childName: string, childBody?: Record<string, unknown>, options?: { asType?: string }) {
-      const child = observation.startObservation(childName, childBody, options);
+      const inheritedSessionId = readSessionId(observation) ?? state.currentSessionId ?? undefined;
+      const propagate = runtime?.propagateAttributes;
+      const createChild = () => observation.startObservation(childName, childBody, options);
+      const child = inheritedSessionId && propagate
+        ? propagate({ sessionId: inheritedSessionId.slice(0, 200) }, createChild)
+        : createChild();
       return wrapObservation(child, store, childName, childBody, options?.asType, id);
     },
     setTraceIO(traceBody?: { input?: unknown; output?: unknown }) {

--- a/test/langfuse.test.ts
+++ b/test/langfuse.test.ts
@@ -1252,3 +1252,70 @@ test("shutdown aborts stalled score HTTP work so a child process exits", async (
 
   assert.deepEqual(result, { code: 0, timedOut: false });
 });
+
+test("child observations inherit the session so v4 session aggregates see them", async () => {
+  const previousConfig = state.config;
+  const sessionId = "01a05f0e-6ae6-714b-beb0-85eca447879a";
+
+  try {
+    ensureOtelContextManager(context, AsyncHooksContextManager);
+    state.config = {
+      publicKey: "pk_test",
+      secretKey: "sk_test",
+      host: "http://127.0.0.1:1",
+    };
+
+    const runtime = await getRuntime();
+    const sessionOf = (observation: unknown) =>
+      (observation as { otelSpan?: { attributes?: Record<string, unknown> } })?.otelSpan?.attributes?.[
+        "session.id"
+      ];
+
+    // Mirrors handlers/agent.ts: only the root is created inside the callback.
+    const root: any = runtime.propagateAttributes({ sessionId, traceName: "pi-agent" }, () =>
+      runtime.startObservation("pi-agent", { input: "hi" }, { asType: "agent" } as any),
+    );
+    // Every later span is created from a separate event handler, outside it.
+    const turn: any = root.startObservation("turn", {}, { asType: "span" });
+    const generation: any = turn.startObservation("llm-generation", {}, { asType: "generation" });
+    const tool: any = turn.startObservation("bash", {}, { asType: "tool" });
+
+    for (const [name, observation] of [
+      ["pi-agent", root],
+      ["turn", turn],
+      ["llm-generation", generation],
+      ["bash", tool],
+    ] as const) {
+      assert.equal(sessionOf(observation), sessionId, `${name} must carry session.id`);
+    }
+
+    for (const observation of [tool, generation, turn, root]) observation.end();
+  } finally {
+    await forceShutdownRuntime();
+    state.config = previousConfig;
+  }
+});
+
+test("child observations without a known session are left unstamped", async () => {
+  const previousConfig = state.config;
+
+  try {
+    state.config = {
+      publicKey: "pk_test",
+      secretKey: "sk_test",
+      host: "http://127.0.0.1:1",
+    };
+
+    const runtime = await getRuntime();
+    const root: any = runtime.startObservation("pi-agent", {}, { asType: "agent" } as any);
+    const turn: any = root.startObservation("turn", {}, { asType: "span" });
+
+    assert.equal(turn?.otelSpan?.attributes?.["session.id"], undefined);
+
+    turn.end();
+    root.end();
+  } finally {
+    await forceShutdownRuntime();
+    state.config = previousConfig;
+  }
+});


### PR DESCRIPTION
Fixes #21.

Only the root `pi-agent` observation was stamped with `session.id`. On Langfuse v4, which aggregates a session over event rows matching `session_id != ''`, that left every session in the project showing a correct trace count beside `Total cost: $0.00` and an empty Usage column.

## Cause

`propagateAttributes` seeds the OTel context; `LangfuseSpanProcessor.onStart(span, parentContext)` is what stamps the propagated attributes onto a span, using the context active at creation. `handlers/agent.ts` wraps only the root creation in that context, and every child is created later from a separate event handler.

## Change

`wrapObservation.startObservation` re-enters the propagated context for each child. That is the single funnel every child passes through — the three `startChildObservation` call sites and the direct `parent.startObservation` in the `session_compact` handler.

The id is read back off the parent span rather than from `state.currentSessionId`. My first attempt used the state and passed my own review but failed the test I wrote against it: a child created outside an active session scope got nothing. Reading the parent's stamped attribute makes inheritance structural, and grandchildren inherit transitively because their parent is stamped by the time they are created.

## Verification

Against the installed package, building the tree exactly as the handlers do:

```
observation          before      after
------------------------------------------
pi-agent (root)      ✅          ✅
turn                 ❌          ✅
llm-generation       ❌          ✅
bash (tool)          ❌          ✅
session_compact      ❌          ✅
```

Running against a live v4.27.0 instance, a session whose Pi session file records two generations at `0.001117025` and `0.000237250` now reports `$0.001354` where it previously reported `$0.00`.

## Tests

Two cases in `test/langfuse.test.ts`, extending the harness the #4 fix introduced. The first asserts the whole tree carries `session.id` when the root is created inside `propagateAttributes`; the second pins the negative case, so a run with no known session stays unstamped rather than inheriting something stale. `npm test` 80/80, `npm run typecheck` clean.

## Note on scope

Sessions already ingested keep their empty `session_id` — events are immutable, so this only takes effect for new runs.

This is independent of #20, which touches `utils.ts` only. The two branches do not overlap.
