### PR TITLE
feat: add LANGFUSE_CAPTURE_PATHS to capture absolute paths verbatim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,12 @@ Relevant implementation details:
 - `src/config.ts` loads saved config first, then env vars.
 - First-run setup is only attempted once per session via `state.setupAttemptedThisSession`.
 - Manual `/langfuse-setup` clears cached config and shuts down the runtime before reconfiguring.
+- Absolute-path hashing (`[PATH_HASH:...]`) is governed by `CapturePolicy.capturePaths`
+  (`LANGFUSE_CAPTURE_PATHS`). Like `captureSourceMetadata` it is `false` in every preset and is
+  excluded from `inferPreset()` in `src/commands.ts`. Callers that hold a policy pass
+  `redactOptionsFor(policy)` into `redactValue()`/`redactString()`; `defaultOptions()` in
+  `src/redaction.ts` falls back to `state.config?.capturePolicy` and defaults to hashing, so a
+  missing policy can never widen disclosure. Secret masking is never affected by this flag.
 
 ## Langfuse-Specific Notes
 

--- a/README.md
+++ b/README.md
@@ -109,11 +109,37 @@ export LANGFUSE_CAPTURE_TOOL_IO=false
 export LANGFUSE_CAPTURE_SYSTEM_PROMPT=false
 export LANGFUSE_CAPTURE_CWD=false
 export LANGFUSE_CAPTURE_SOURCE_METADATA=false
+export LANGFUSE_CAPTURE_PATHS=false
 ```
 
 Source metadata remains off in every preset unless `LANGFUSE_CAPTURE_SOURCE_METADATA=true` is set explicitly.
+The same holds for absolute paths and `LANGFUSE_CAPTURE_PATHS`.
 
 All captured payloads are redacted before upload. The extension masks common API keys, bearer tokens, passwords, cookies, private keys, Langfuse keys, GitHub/npm/AWS-style tokens, and local absolute paths.
+
+### Absolute paths
+
+By default, local absolute paths (`/Users/...`, `/home/...`, `/tmp/...`, `C:\Users\...`) are
+replaced everywhere with a stable `[PATH_HASH:<12 hex chars>]` digest, so usernames and repository
+names never reach Langfuse. This applies to inputs, outputs, tool I/O, tool error messages, and the
+`cwd` metadata field. Opt in to see real paths in traces:
+
+```bash
+export LANGFUSE_CAPTURE_PATHS=true
+```
+
+Or persist it in `config.json`:
+
+```json
+{ "capture": { "LANGFUSE_CAPTURE_PATHS": "true" } }
+```
+
+Like `LANGFUSE_CAPTURE_SOURCE_METADATA`, this stays off in every privacy preset until it is set
+explicitly, and it only affects paths — secret masking (tokens, keys, cookies, passwords) is always
+on regardless. Note that `LANGFUSE_CAPTURE_CWD=false` is a different control: it drops the `cwd`
+metadata field entirely rather than changing how paths are rendered.
+
+`/langfuse-status` reports the current setting under `Capture: absolute paths`.
 
 ### Payload limits
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -109,11 +109,35 @@ export LANGFUSE_CAPTURE_TOOL_IO=false
 export LANGFUSE_CAPTURE_SYSTEM_PROMPT=false
 export LANGFUSE_CAPTURE_CWD=false
 export LANGFUSE_CAPTURE_SOURCE_METADATA=false
+export LANGFUSE_CAPTURE_PATHS=false
 ```
 
 所有隐私预设默认都关闭源码元数据；只有显式设置 `LANGFUSE_CAPTURE_SOURCE_METADATA=true` 才会启用。
+绝对路径与 `LANGFUSE_CAPTURE_PATHS` 同理。
 
 所有被采集的负载在上传前仍会脱敏。扩展会隐藏常见 API key、Bearer token、密码、Cookie、私钥、Langfuse key、GitHub/npm/AWS 风格 token，并对本地绝对路径做 hash。
+
+### 绝对路径
+
+默认情况下，本地绝对路径（`/Users/...`、`/home/...`、`/tmp/...`、`C:\Users\...`）会在所有位置被替换为
+稳定的 `[PATH_HASH:<12 位十六进制>]` 摘要，因此用户名和仓库名不会进入 Langfuse。该规则作用于输入、输出、
+工具 I/O、工具错误信息以及 `cwd` 元数据字段。若希望在 trace 中看到真实路径，需要显式开启：
+
+```bash
+export LANGFUSE_CAPTURE_PATHS=true
+```
+
+也可以持久化到 `config.json`：
+
+```json
+{ "capture": { "LANGFUSE_CAPTURE_PATHS": "true" } }
+```
+
+与 `LANGFUSE_CAPTURE_SOURCE_METADATA` 一样，它在所有隐私预设中默认关闭，且只影响路径；密钥脱敏（token、key、
+Cookie、密码）始终生效。注意 `LANGFUSE_CAPTURE_CWD=false` 是另一个控制项——它会直接丢弃 `cwd` 元数据字段，
+而不是改变路径的呈现方式。
+
+`/langfuse-status` 会在 `Capture: absolute paths` 下显示当前设置。
 
 ### 负载上限
 

--- a/src/capture-policy.ts
+++ b/src/capture-policy.ts
@@ -1,4 +1,4 @@
-import { hashPath, redactValue } from "./redaction.js";
+import { hashPath, redactValue, type RedactOptions } from "./redaction.js";
 
 export interface CapturePolicy {
   readonly captureInputs: boolean;
@@ -7,6 +7,17 @@ export interface CapturePolicy {
   readonly captureSystemPrompt: boolean;
   readonly captureCwd: boolean;
   readonly captureSourceMetadata: boolean;
+  /**
+   * Capture local absolute paths verbatim. Off in every preset, like
+   * `captureSourceMetadata`: paths are replaced with `[PATH_HASH:...]` unless
+   * `LANGFUSE_CAPTURE_PATHS` opts in explicitly.
+   */
+  readonly capturePaths: boolean;
+}
+
+/** Redaction options implied by a policy, so path rendering follows the same switch everywhere. */
+export function redactOptionsFor(policy: CapturePolicy): Partial<RedactOptions> {
+  return { redactPaths: !policy.capturePaths };
 }
 
 export type PrivacyPreset = "metadata-only" | "prompts-only" | "conversations" | "full-debug";
@@ -38,6 +49,7 @@ const PRESETS: Record<PrivacyPreset, CapturePolicy> = {
     captureSystemPrompt: false,
     captureCwd: false,
     captureSourceMetadata: false,
+    capturePaths: false,
   },
   "prompts-only": {
     captureInputs: true,
@@ -46,6 +58,7 @@ const PRESETS: Record<PrivacyPreset, CapturePolicy> = {
     captureSystemPrompt: false,
     captureCwd: false,
     captureSourceMetadata: false,
+    capturePaths: false,
   },
   conversations: {
     captureInputs: true,
@@ -54,6 +67,7 @@ const PRESETS: Record<PrivacyPreset, CapturePolicy> = {
     captureSystemPrompt: false,
     captureCwd: false,
     captureSourceMetadata: false,
+    capturePaths: false,
   },
   "full-debug": {
     captureInputs: true,
@@ -62,6 +76,7 @@ const PRESETS: Record<PrivacyPreset, CapturePolicy> = {
     captureSystemPrompt: true,
     captureCwd: true,
     captureSourceMetadata: false,
+    capturePaths: false,
   },
 };
 
@@ -72,6 +87,7 @@ const FLAG_TO_FIELD = {
   LANGFUSE_CAPTURE_SYSTEM_PROMPT: "captureSystemPrompt",
   LANGFUSE_CAPTURE_CWD: "captureCwd",
   LANGFUSE_CAPTURE_SOURCE_METADATA: "captureSourceMetadata",
+  LANGFUSE_CAPTURE_PATHS: "capturePaths",
 } as const;
 
 function parseFlag(value: string | undefined): boolean | undefined {
@@ -109,18 +125,20 @@ function redactMetadata(metadata: Record<string, unknown> | undefined, policy: C
     return undefined;
   }
 
+  const redactOptions = redactOptionsFor(policy);
   const output: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(metadata)) {
     if (key === "cwd") {
       if (!policy.captureCwd) {
         continue;
       }
-      output[key] = typeof value === "string" && /^(?:\/|[A-Za-z]:[\\/]|\\\\)/.test(value)
-        ? hashPath(value)
-        : redactValue(value);
+      output[key] =
+        !policy.capturePaths && typeof value === "string" && /^(?:\/|[A-Za-z]:[\\/]|\\\\)/.test(value)
+          ? hashPath(value)
+          : redactValue(value, redactOptions);
       continue;
     }
-    output[key] = redactValue(value);
+    output[key] = redactValue(value, redactOptions);
   }
   return Object.keys(output).length > 0 ? output : undefined;
 }
@@ -129,24 +147,25 @@ export function applyCapturePolicy(
   payload: RawTelemetryPayload,
   policy: CapturePolicy = createCapturePolicy(),
 ): CapturedTelemetryPayload {
+  const redactOptions = redactOptionsFor(policy);
   const captured: CapturedTelemetryPayload = {
     metadata: redactMetadata(payload.metadata, policy),
   };
 
   if (policy.captureInputs && "input" in payload) {
-    captured.input = redactValue(payload.input);
+    captured.input = redactValue(payload.input, redactOptions);
   }
   if (policy.captureOutputs && "output" in payload) {
-    captured.output = redactValue(payload.output);
+    captured.output = redactValue(payload.output, redactOptions);
   }
   if (policy.captureToolIo && "toolInput" in payload) {
-    captured.toolInput = redactValue(payload.toolInput);
+    captured.toolInput = redactValue(payload.toolInput, redactOptions);
   }
   if (policy.captureToolIo && "toolOutput" in payload) {
-    captured.toolOutput = redactValue(payload.toolOutput);
+    captured.toolOutput = redactValue(payload.toolOutput, redactOptions);
   }
   if (policy.captureSystemPrompt && "systemPrompt" in payload) {
-    captured.systemPrompt = redactValue(payload.systemPrompt);
+    captured.systemPrompt = redactValue(payload.systemPrompt, redactOptions);
   }
 
   return captured;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -75,7 +75,7 @@ function isPrivacyPreset(value: string | undefined): value is PrivacyPreset {
 }
 
 function inferPreset(policy: CapturePolicy): PrivacyPreset | "custom" {
-  const entries: Array<[PrivacyPreset, Omit<CapturePolicy, "captureSourceMetadata">]> = [
+  const entries: Array<[PrivacyPreset, Omit<CapturePolicy, "captureSourceMetadata" | "capturePaths">]> = [
     [
       "metadata-only",
       {
@@ -140,6 +140,7 @@ function describePolicy(policy: CapturePolicy) {
     `captureSystemPrompt: ${policy.captureSystemPrompt}`,
     `captureCwd: ${policy.captureCwd}`,
     `captureSourceMetadata: ${policy.captureSourceMetadata}`,
+    `capturePaths: ${policy.capturePaths}`,
   ].join("\n");
 }
 
@@ -218,6 +219,7 @@ function formatStatus(configPath: string, env: Record<string, string | undefined
     `  tool IO: ${flag(policy.captureToolIo)}`,
     `  system prompt: ${flag(policy.captureSystemPrompt)}`,
     `  cwd: ${flag(policy.captureCwd)}`,
+    `  absolute paths: ${flag(policy.capturePaths)}`,
     `Active run: ${hasActiveAgentObservation() ? "yes" : "no"}`,
     `Last error: ${lastErrorSummary()}`,
   ].join("\n");

--- a/src/handlers/tool.ts
+++ b/src/handlers/tool.ts
@@ -12,7 +12,7 @@ import {
   getCapturePolicy,
   getLimits,
 } from "../utils.js";
-import { applyCapturePolicy } from "../capture-policy.js";
+import { applyCapturePolicy, redactOptionsFor } from "../capture-policy.js";
 import { redactString } from "../redaction.js";
 
 export async function startToolObservation(event: Record<string, unknown>) {
@@ -87,6 +87,7 @@ export async function finishToolObservation(event: Record<string, unknown>) {
     event;
 
   try {
+    const policy = getCapturePolicy();
     const shapedOutput = shapePayload(output, { maxString: getLimits().maxToolPayload });
     const captured = applyCapturePolicy(
       {
@@ -97,7 +98,7 @@ export async function finishToolObservation(event: Record<string, unknown>) {
           isError,
         },
       },
-      getCapturePolicy(),
+      policy,
     );
     const outputBytes = estimatePayloadBytes(captured.toolOutput, getLimits().maxToolPayload);
     const durationMs = Math.max(0, Date.now() - activeTool.startedAt);
@@ -106,7 +107,9 @@ export async function finishToolObservation(event: Record<string, unknown>) {
       .update({
         output: captured.toolOutput,
         level: isError ? "ERROR" : "DEFAULT",
-        statusMessage: isError ? redactString(truncate(String(event.error ?? output), 1_000)) : undefined,
+        statusMessage: isError
+          ? redactString(truncate(String(event.error ?? output), 1_000), redactOptionsFor(policy))
+          : undefined,
         metadata: {
           ...(captured.metadata ?? {}),
           durationMs,

--- a/src/redaction.ts
+++ b/src/redaction.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { getLimits } from "./limits.js";
+import { state } from "./state.js";
 
 export const REDACTED = "[REDACTED_SECRET]";
 
@@ -8,8 +9,16 @@ export interface RedactOptions {
   maxArrayItems: number;
   maxObjectKeys: number;
   maxStringLength: number;
+  /** When false, absolute filesystem paths are emitted verbatim instead of `[PATH_HASH:...]`. */
+  redactPaths: boolean;
 }
 
+/**
+ * Fallback for callers that do not pass the resolved capture policy. Mirrors
+ * `getLimits()` by reading the session config, and defaults to redacting so a
+ * missing policy can never widen disclosure. Callers that hold a policy should
+ * pass `redactOptionsFor(policy)` instead of relying on this.
+ */
 function defaultOptions(): RedactOptions {
   const limits = getLimits();
   return {
@@ -17,6 +26,7 @@ function defaultOptions(): RedactOptions {
     maxArrayItems: limits.maxArrayItems,
     maxObjectKeys: limits.maxObjectKeys,
     maxStringLength: limits.maxString,
+    redactPaths: !(state.config?.capturePolicy?.capturePaths ?? false),
   };
 }
 
@@ -41,16 +51,20 @@ function truncate(value: string, maxStringLength: number): string {
 
 export function redactString(value: string, options: Partial<RedactOptions> = {}): string {
   const merged = { ...defaultOptions(), ...options };
-  const truncated = truncate(value, merged.maxStringLength);
-  return truncated
+  const secretsRedacted = truncate(value, merged.maxStringLength)
     .replace(PRIVATE_KEY_RE, REDACTED)
     .replace(BEARER_RE, REDACTED)
     .replace(KNOWN_TOKEN_RE, REDACTED)
-    .replace(SECRET_ASSIGNMENT_RE, (_match, key: string) => `${key}=${REDACTED}`)
-    .replace(ABSOLUTE_PATH_RE, (path: string) => {
-      const envSuffix = path.match(/([/\\]\.env(?:\.[A-Za-z0-9_-]+)?)$/)?.[1];
-      return `${hashPath(envSuffix ? path.slice(0, -envSuffix.length) : path)}${envSuffix ?? ""}`;
-    });
+    .replace(SECRET_ASSIGNMENT_RE, (_match, key: string) => `${key}=${REDACTED}`);
+
+  if (!merged.redactPaths) {
+    return secretsRedacted;
+  }
+
+  return secretsRedacted.replace(ABSOLUTE_PATH_RE, (path: string) => {
+    const envSuffix = path.match(/([/\\]\.env(?:\.[A-Za-z0-9_-]+)?)$/)?.[1];
+    return `${hashPath(envSuffix ? path.slice(0, -envSuffix.length) : path)}${envSuffix ?? ""}`;
+  });
 }
 
 function visit(value: unknown, options: RedactOptions, depth: number, seen: WeakSet<object>): unknown {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { getLimits } from "./limits.js";
-import { createCapturePolicy, type CapturePolicy } from "./capture-policy.js";
+import { createCapturePolicy, redactOptionsFor, type CapturePolicy } from "./capture-policy.js";
 import { redactValue } from "./redaction.js";
 import { state } from "./state.js";
 
@@ -140,6 +140,7 @@ export function shapePayload(
   return options.redact === false
     ? shaped
     : redactValue(shaped, {
+        ...redactOptionsFor(getCapturePolicy()),
         maxDepth: depth,
         maxStringLength: maxString,
         maxArrayItems,

--- a/test/capture-policy.test.ts
+++ b/test/capture-policy.test.ts
@@ -13,6 +13,7 @@ test("defaults to full-debug capture to preserve existing trace detail", () => {
     captureSystemPrompt: true,
     captureCwd: true,
     captureSourceMetadata: false,
+    capturePaths: false,
   });
 });
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -32,7 +32,28 @@ test("env privacy flags override saved config capture policy", () => {
     captureSystemPrompt: false,
     captureCwd: false,
     captureSourceMetadata: true,
+    capturePaths: false,
   });
+});
+
+test("saved capture block enables absolute paths, and env still wins over it", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-langfuse-config-paths-"));
+  const configPath = join(dir, "config.json");
+  writeFileSync(
+    configPath,
+    JSON.stringify({
+      publicKey: "pk-lf-test",
+      secretKey: "sk-lf-test",
+      host: "https://cloud.langfuse.com",
+      capture: { LANGFUSE_CAPTURE_PATHS: "true" },
+    }),
+  );
+
+  assert.equal(loadConfigFromFile(configPath, {})?.capturePolicy?.capturePaths, true);
+  assert.equal(
+    loadConfigFromFile(configPath, { LANGFUSE_CAPTURE_PATHS: "false" })?.capturePolicy?.capturePaths,
+    false,
+  );
 });
 
 test("saved config is private and sanitized config does not reveal secret key", () => {

--- a/test/redaction.test.ts
+++ b/test/redaction.test.ts
@@ -2,7 +2,24 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { redactString, redactValue } from "../src/redaction.ts";
+import { applyCapturePolicy, createCapturePolicy, redactOptionsFor } from "../src/capture-policy.ts";
+import { state } from "../src/state.ts";
 import { shapePayload } from "../src/utils.ts";
+
+const PATHS_ON = createCapturePolicy({
+  LANGFUSE_PRIVACY_PRESET: "full-debug",
+  LANGFUSE_CAPTURE_PATHS: "true",
+});
+
+function withConfigPolicy<T>(policy: ReturnType<typeof createCapturePolicy>, run: () => T): T {
+  const previous = state.config;
+  state.config = { publicKey: "pk", secretKey: "sk", host: "https://example.test", capturePolicy: policy };
+  try {
+    return run();
+  } finally {
+    state.config = previous;
+  }
+}
 
 test("redacts common secrets recursively before telemetry upload", () => {
   const fakeProviderKey = ["sk", "ant", "api03", "fake-test-abcdefghijklmnop"].join("-");
@@ -46,6 +63,63 @@ test("shapePayload applies redaction while preserving truncation and circular ha
   assert.equal(shaped.token, "[REDACTED_SECRET]");
   assert.match(String(shaped.cwd), /^\[PATH_HASH:[a-f0-9]{12}\]$/);
   assert.equal(shaped.self, "[circular]");
+});
+
+test("capturePaths is off in every preset unless opted into explicitly", () => {
+  for (const preset of ["metadata-only", "prompts-only", "conversations", "full-debug"]) {
+    assert.equal(createCapturePolicy({ LANGFUSE_PRIVACY_PRESET: preset }).capturePaths, false, preset);
+  }
+  assert.equal(createCapturePolicy({ LANGFUSE_CAPTURE_PATHS: "true" }).capturePaths, true);
+  assert.equal(createCapturePolicy({ LANGFUSE_CAPTURE_PATHS: "false" }).capturePaths, false);
+  assert.equal(createCapturePolicy({}).capturePaths, false);
+});
+
+test("LANGFUSE_CAPTURE_PATHS keeps paths verbatim but still redacts secrets", () => {
+  assert.equal(
+    redactString("Wrote /Users/alice/work/private-repo/.env", redactOptionsFor(PATHS_ON)),
+    "Wrote /Users/alice/work/private-repo/.env",
+  );
+
+  const captured = applyCapturePolicy(
+    {
+      input: "read /Users/alice/work/private-repo/src/index.ts",
+      metadata: { cwd: "/Users/alice/work/private-repo" },
+    },
+    PATHS_ON,
+  );
+  assert.equal(captured.metadata?.cwd, "/Users/alice/work/private-repo");
+  assert.equal(captured.input, "read /Users/alice/work/private-repo/src/index.ts");
+
+  const stillMasked = redactValue(
+    { token: "ghp_abcdefghijklmnopqrstuvwxyz123456", cwd: "/Users/alice/work/private-repo" },
+    redactOptionsFor(PATHS_ON),
+  ) as Record<string, unknown>;
+  assert.equal(stillMasked.token, "[REDACTED_SECRET]");
+  assert.equal(stillMasked.cwd, "/Users/alice/work/private-repo");
+});
+
+test("shapePayload follows the session capture policy for path rendering", () => {
+  const payload = { cwd: "/Users/alice/work/private-repo", token: "ghp_abcdefghijklmnopqrstuvwxyz123456" };
+
+  const optedIn = withConfigPolicy(PATHS_ON, () => shapePayload(payload) as Record<string, unknown>);
+  assert.equal(optedIn.cwd, "/Users/alice/work/private-repo");
+  assert.equal(optedIn.token, "[REDACTED_SECRET]");
+
+  const defaulted = withConfigPolicy(
+    createCapturePolicy({ LANGFUSE_PRIVACY_PRESET: "full-debug" }),
+    () => shapePayload(payload) as Record<string, unknown>,
+  );
+  assert.match(String(defaulted.cwd), /^\[PATH_HASH:[a-f0-9]{12}\]$/);
+});
+
+test("redaction falls back to hashing when no capture policy is resolved", () => {
+  const previous = state.config;
+  state.config = null;
+  try {
+    assert.match(redactString("/Users/alice/work/private-repo"), /^\[PATH_HASH:[a-f0-9]{12}\]$/);
+  } finally {
+    state.config = previous;
+  }
 });
 
 test("redacts camelCase credential field names", () => {


### PR DESCRIPTION
Fixes #25.

Absolute paths were rewritten to `[PATH_HASH:<12 hex>]` unconditionally, with no configuration path to turn it off. On a self-hosted instance that costs the most useful debugging signal in a tool observation — which file was touched — for a privacy guarantee the operator does not need against themselves.

## Cause

Two independent hashing sites, neither of them switchable:

- `redactString()` ended its chain with `.replace(ABSOLUTE_PATH_RE, ...)`. Since `redactValue()` funnels every string through it, this reached all shaped payloads (`shapePayload()`, `src/utils.ts:140`), all policy-captured fields, and tool error `statusMessage` (`handlers/tool.ts:109`).
- `redactMetadata()` hashed the `cwd` key through a separate `hashPath()` call (`src/capture-policy.ts:119`).

`shapePayload({ redact: false })` was declared in the options type but no call site passed it, and it was not reachable from configuration.

## Change

A new `capturePaths` field on `CapturePolicy`, resolved from `LANGFUSE_CAPTURE_PATHS`:

```bash
export LANGFUSE_CAPTURE_PATHS=true
```

```json
{ "capture": { "LANGFUSE_CAPTURE_PATHS": "true" } }
```

It is `false` in all four presets, so nothing changes unless it is set.

**Why `CapturePolicy` rather than a standalone env knob.** My first draft added `PI_LANGFUSE_REDACT_PATHS`, resolved per-call from `process.env`. That was wrong on three counts, and `captureSourceMetadata` is the counter-example that shows it:

- *Not configurable.* `captureSource` — the merged `{...config.capture, ...privacyPreset, ...env}` bag — only reaches `createCapturePolicy()`. Anything resolved outside it cannot be persisted in `config.json`. Living in `CapturePolicy` makes the `capture` block work with no changes to `config.ts`.
- *Not snapshotted.* `capturePolicy` and `limits` both freeze at config load and are read back through `state.config`. A per-call `process.env` read would flip mid-trace where the other two would not.
- *Invisible.* `describePolicy()` and `/langfuse-status` enumerate policy fields; a flag outside the policy has nothing to report.

The objection to putting it in `CapturePolicy` is that it is orthogonal to the presets — but `captureSourceMetadata` already establishes exactly that shape: uniform across all four presets, excluded from `inferPreset()` via `Omit`, still listed in `describePolicy()`. `capturePaths` is its mirror image, so `inferPreset`'s `Omit` grows to `"captureSourceMetadata" | "capturePaths"` and preset inference is unaffected.

Framing it as opt-in (`LANGFUSE_CAPTURE_PATHS=true` reveals) rather than opt-out (`REDACT_PATHS=false` disables) keeps the naming consistent with the rest of the family and keeps the safe state the default one.

**Redaction plumbing.** `redactOptionsFor(policy)` derives `{ redactPaths: !policy.capturePaths }`, and the three call sites that hold a policy pass it in: `applyCapturePolicy()`, `shapePayload()` via `getCapturePolicy()`, and the tool `statusMessage`. `defaultOptions()` in `redaction.ts` falls back to `state.config?.capturePolicy?.capturePaths ?? false` — reading `state.js` directly, which avoids a `redaction ↔ capture-policy` import cycle, and failing closed so a missing policy hashes rather than discloses.

**Secrets stay unconditional.** `redactString()` previously built one `.replace` chain, so gating it wholesale would have let this flag disable token masking too. Secret replacements now run first and return early when paths are opted in, which makes it structurally impossible for this switch to leak a credential.

`redactMetadata()` consults the same field, so `cwd` is emitted verbatim rather than falling back to a different rendering. This stays distinct from `LANGFUSE_CAPTURE_CWD=false`, which drops the field — both READMEs spell out the difference, since the two are easy to confuse.

## Tests

Five cases, 85/85 passing:

- `capturePaths` is `false` in every preset and flips only on explicit `LANGFUSE_CAPTURE_PATHS`.
- Opted in, paths survive verbatim through `redactString()`, `applyCapturePolicy()` inputs, and the `cwd` metadata key — asserted in the same payloads where a `ghp_` token still becomes `[REDACTED_SECRET]`.
- `shapePayload()` follows the session policy: verbatim under an opted-in `state.config`, hashed under a default `full-debug` one.
- With `state.config = null`, `redactString()` still hashes — pins the fail-closed fallback.
- `config.json`'s `capture` block enables it, and an env var of the opposite value still wins — pins the documented precedence.

The existing tests that pin hashing behaviour (`test/capture-policy.test.ts`, `test/source-metadata.test.ts`) are untouched and still pass, which is the regression guard for the default.

`npm run typecheck` clean.

## One interaction worth flagging

`applyPrivacyPreset()` in `src/commands.ts` rebuilds the config as `{publicKey, secretKey, host, privacyPreset}`, dropping any saved `capture` block. So `/langfuse-privacy preset=...` clears a persisted `LANGFUSE_CAPTURE_PATHS`, exactly as it already clears a persisted `LANGFUSE_CAPTURE_SOURCE_METADATA`. That is pre-existing behaviour and out of scope here, but this change gives it one more thing to drop — happy to fix it in a follow-up if you want it preserved.
