### PR TITLE
fix: carry every propagated trace attribute onto child observations

### DIFF
--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -463,25 +463,63 @@ function observationType(asType?: string): FallbackObservationType {
  * `LangfuseSpanProcessor.onStart(span, parentContext)`, reading them from the
  * OTel context that was active when the span was created. `propagateAttributes`
  * only seeds that context for the duration of its callback, so a child created
- * later — from a separate event handler, outside the callback — is written with
- * an empty `session.id`.
+ * later — from a separate event handler, outside the callback — is written
+ * without `session.id`, `langfuse.trace.name`, or `langfuse.trace.metadata.*`.
  *
- * That is invisible in the legacy data model, where the session lives on the
- * trace, but Langfuse v4 stores `session_id` per event row and aggregates a
- * session with `WHERE session_id != ''`. Unstamped children drop out of
- * `sumMap(cost_details)` and `sumMap(usage_details)`, which is why such
- * sessions report their trace count correctly but no cost and no usage at all.
+ * That is invisible in the legacy data model, where those live on the trace,
+ * but Langfuse v4 stores them per event row and filters and aggregates over
+ * those rows: a session is `WHERE session_id != ''`, and cost by trace name
+ * matches `trace_name` on the generation itself. Unstamped children drop out
+ * of `sumMap(cost_details)` and `sumMap(usage_details)`, which is why such
+ * sessions and trace-name filters report a correct trace count but no cost
+ * and no usage at all.
  *
- * Re-entering the propagated context for every child keeps the whole tree in
- * the session. The id is read back off the parent span rather than from
- * `state.currentSessionId`, so a child created outside an active session scope
- * still inherits whatever its parent was actually stamped with.
+ * Re-entering the propagated context for every child keeps the whole tree
+ * queryable. The attributes are read back off the parent span rather than
+ * from state, so a child created outside an active session scope still
+ * inherits whatever its parent was actually stamped with, and grandchildren
+ * inherit transitively.
  */
-const OTEL_SESSION_ID_ATTRIBUTE = "session.id";
+type PropagatedAttributes = Parameters<LangfuseRuntime["propagateAttributes"]>[0];
 
-function readSessionId(observation: any): string | undefined {
-  const value = observation?.otelSpan?.attributes?.[OTEL_SESSION_ID_ATTRIBUTE];
-  return typeof value === "string" && value ? value : undefined;
+const PROPAGATED_STRING_ATTRIBUTES = {
+  sessionId: "session.id",
+  userId: "user.id",
+  traceName: "langfuse.trace.name",
+} as const;
+const OTEL_TRACE_TAGS_ATTRIBUTE = "langfuse.trace.tags";
+const OTEL_TRACE_METADATA_PREFIX = "langfuse.trace.metadata.";
+
+function readPropagatedAttributes(observation: any): PropagatedAttributes {
+  const attributes: Record<string, unknown> = observation?.otelSpan?.attributes ?? {};
+  const propagated: PropagatedAttributes = {};
+
+  for (const [key, attribute] of Object.entries(PROPAGATED_STRING_ATTRIBUTES)) {
+    const value = attributes[attribute];
+    if (typeof value === "string" && value) {
+      propagated[key as keyof typeof PROPAGATED_STRING_ATTRIBUTES] = value;
+    }
+  }
+
+  const tags = attributes[OTEL_TRACE_TAGS_ATTRIBUTE];
+  if (Array.isArray(tags)) {
+    const validTags = tags.filter((tag): tag is string => typeof tag === "string" && tag.length > 0);
+    if (validTags.length > 0) {
+      propagated.tags = validTags;
+    }
+  }
+
+  const metadata: Record<string, string> = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (key.startsWith(OTEL_TRACE_METADATA_PREFIX) && typeof value === "string") {
+      metadata[key.slice(OTEL_TRACE_METADATA_PREFIX.length)] = value;
+    }
+  }
+  if (Object.keys(metadata).length > 0) {
+    propagated.metadata = metadata;
+  }
+
+  return propagated;
 }
 
 function wrapObservation(
@@ -543,11 +581,15 @@ function wrapObservation(
       return observation.end();
     },
     startObservation(childName: string, childBody?: Record<string, unknown>, options?: { asType?: string }) {
-      const inheritedSessionId = readSessionId(observation) ?? state.currentSessionId ?? undefined;
+      const inherited = readPropagatedAttributes(observation);
+      const fallbackSessionId = state.currentSessionId?.slice(0, 200);
+      if (!inherited.sessionId && fallbackSessionId) {
+        inherited.sessionId = fallbackSessionId;
+      }
       const propagate = runtime?.propagateAttributes;
       const createChild = () => observation.startObservation(childName, childBody, options);
-      const child = inheritedSessionId && propagate
-        ? propagate({ sessionId: inheritedSessionId.slice(0, 200) }, createChild)
+      const child = propagate && Object.keys(inherited).length > 0
+        ? propagate(inherited, createChild)
         : createChild();
       return wrapObservation(child, store, childName, childBody, options?.asType, id);
     },

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -479,6 +479,15 @@ function observationType(asType?: string): FallbackObservationType {
  * from state, so a child created outside an active session scope still
  * inherits whatever its parent was actually stamped with, and grandchildren
  * inherit transitively.
+ *
+ * The re-entry runs on the OTel root context, not the ambient one.
+ * `propagateAttributes` starts from `context.active()`, merges `metadata`
+ * and `tags` with whatever that context already carries, and stamps the
+ * active span if there is one. Any attributes propagated by the caller —
+ * another instrumentation, a foreign `propagateAttributes` scope — would
+ * otherwise leak into the child or onto an unrelated span. The parent is
+ * still explicit: `observation.startObservation` passes the parent span
+ * context to the child, so a clean ambient context changes nothing else.
  */
 type PropagatedAttributes = Parameters<LangfuseRuntime["propagateAttributes"]>[0];
 
@@ -486,6 +495,7 @@ const PROPAGATED_STRING_ATTRIBUTES = {
   sessionId: "session.id",
   userId: "user.id",
   traceName: "langfuse.trace.name",
+  version: "langfuse.version",
 } as const;
 const OTEL_TRACE_TAGS_ATTRIBUTE = "langfuse.trace.tags";
 const OTEL_TRACE_METADATA_PREFIX = "langfuse.trace.metadata.";
@@ -588,9 +598,12 @@ function wrapObservation(
       }
       const propagate = runtime?.propagateAttributes;
       const createChild = () => observation.startObservation(childName, childBody, options);
-      const child = propagate && Object.keys(inherited).length > 0
-        ? propagate(inherited, createChild)
-        : createChild();
+      const createInheritingChild = propagate && Object.keys(inherited).length > 0
+        ? () => propagate(inherited, createChild)
+        : createChild;
+      const child = runtime?.withRootContext
+        ? runtime.withRootContext(createInheritingChild)
+        : createInheritingChild();
       return wrapObservation(child, store, childName, childBody, options?.asType, id);
     },
     setTraceIO(traceBody?: { input?: unknown; output?: unknown }) {
@@ -819,7 +832,7 @@ export async function getRuntime(): Promise<LangfuseRuntime> {
     const [
       { BasicTracerProvider },
       { resources },
-      { context },
+      { context, ROOT_CONTEXT },
       { AsyncHooksContextManager },
       { LangfuseSpanProcessor },
       tracing,
@@ -864,6 +877,7 @@ export async function getRuntime(): Promise<LangfuseRuntime> {
           return wrapObservation(observation, restFallback, name, body, options?.asType);
         }) as unknown as LangfuseRuntime["startObservation"],
         propagateAttributes: tracing.propagateAttributes as unknown as LangfuseRuntime["propagateAttributes"],
+        withRootContext: (fn) => context.with(ROOT_CONTEXT, fn),
         scoreClient: new LangfuseClient({
           publicKey: state.config.publicKey,
           secretKey: state.config.secretKey,

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,11 +87,18 @@ export interface LangfuseRuntime {
       sessionId?: string;
       userId?: string;
       traceName?: string;
+      version?: string;
       metadata?: Record<string, string>;
       tags?: string[];
     },
     fn: () => LangfuseObservation,
   ) => LangfuseObservation;
+  /**
+   * Runs `fn` on the OTel root context, so the observations it creates take
+   * their propagated attributes only from what is passed explicitly and not
+   * from whatever the caller's ambient context happens to carry.
+   */
+  withRootContext?: <T>(fn: () => T) => T;
   scoreClient: LangfuseScoreClient;
   spanProcessor?: { forceFlush?: () => Promise<void>; shutdown?: () => Promise<void> };
   tracerProvider?: { forceFlush?: () => Promise<void>; shutdown?: () => Promise<void> };

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,7 @@ export interface LangfuseRuntime {
   propagateAttributes: (
     params: {
       sessionId?: string;
+      userId?: string;
       traceName?: string;
       metadata?: Record<string, string>;
       tags?: string[];

--- a/test/langfuse.test.ts
+++ b/test/langfuse.test.ts
@@ -1253,7 +1253,7 @@ test("shutdown aborts stalled score HTTP work so a child process exits", async (
   assert.deepEqual(result, { code: 0, timedOut: false });
 });
 
-test("child observations inherit the session so v4 session aggregates see them", async () => {
+test("child observations inherit every propagated trace attribute so v4 filters see them", async () => {
   const previousConfig = state.config;
   const sessionId = "01a05f0e-6ae6-714b-beb0-85eca447879a";
 
@@ -1266,15 +1266,22 @@ test("child observations inherit the session so v4 session aggregates see them",
     };
 
     const runtime = await getRuntime();
-    const sessionOf = (observation: unknown) =>
-      (observation as { otelSpan?: { attributes?: Record<string, unknown> } })?.otelSpan?.attributes?.[
-        "session.id"
-      ];
+    const attributesOf = (observation: unknown) =>
+      (observation as { otelSpan?: { attributes?: Record<string, unknown> } })?.otelSpan?.attributes ?? {};
 
     // Mirrors handlers/agent.ts: only the root is created inside the callback.
-    const root: any = runtime.propagateAttributes({ sessionId, traceName: "pi-agent" }, () =>
-      runtime.startObservation("pi-agent", { input: "hi" }, { asType: "agent" } as any),
+    const root: any = runtime.propagateAttributes(
+      {
+        sessionId,
+        userId: "user-1",
+        traceName: "pi-agent",
+        tags: ["pi", "cli"],
+        metadata: { model: "claude-sonnet-4", provider: "anthropic" },
+      },
+      () => runtime.startObservation("pi-agent", { input: "hi" }, { asType: "agent" } as any),
     );
+    // Observation-level metadata is per span and must not travel to children.
+    root.update({ metadata: { systemPrompt: "You are Pi." } });
     // Every later span is created from a separate event handler, outside it.
     const turn: any = root.startObservation("turn", {}, { asType: "span" });
     const generation: any = turn.startObservation("llm-generation", {}, { asType: "generation" });
@@ -1286,7 +1293,17 @@ test("child observations inherit the session so v4 session aggregates see them",
       ["llm-generation", generation],
       ["bash", tool],
     ] as const) {
-      assert.equal(sessionOf(observation), sessionId, `${name} must carry session.id`);
+      const attributes = attributesOf(observation);
+      assert.equal(attributes["session.id"], sessionId, `${name} must carry session.id`);
+      assert.equal(attributes["user.id"], "user-1", `${name} must carry user.id`);
+      assert.equal(attributes["langfuse.trace.name"], "pi-agent", `${name} must carry langfuse.trace.name`);
+      assert.deepEqual(attributes["langfuse.trace.tags"], ["pi", "cli"], `${name} must carry langfuse.trace.tags`);
+      assert.equal(attributes["langfuse.trace.metadata.model"], "claude-sonnet-4", `${name} must carry trace metadata`);
+      assert.equal(attributes["langfuse.trace.metadata.provider"], "anthropic", `${name} must carry trace metadata`);
+    }
+
+    for (const observation of [turn, generation, tool]) {
+      assert.equal(attributesOf(observation)["langfuse.observation.metadata.systemPrompt"], undefined);
     }
 
     for (const observation of [tool, generation, turn, root]) observation.end();

--- a/test/langfuse.test.ts
+++ b/test/langfuse.test.ts
@@ -17,7 +17,7 @@ import type { LangfuseRuntime } from "../src/types.js";
 import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
 import { LangfuseSpanProcessor } from "@langfuse/otel";
 import * as tracing from "@langfuse/tracing";
-import { context } from "@opentelemetry/api";
+import { context, trace } from "@opentelemetry/api";
 import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 
 function never(): Promise<void> {
@@ -1275,6 +1275,7 @@ test("child observations inherit every propagated trace attribute so v4 filters 
         sessionId,
         userId: "user-1",
         traceName: "pi-agent",
+        version: "1.5.16",
         tags: ["pi", "cli"],
         metadata: { model: "claude-sonnet-4", provider: "anthropic" },
       },
@@ -1297,6 +1298,7 @@ test("child observations inherit every propagated trace attribute so v4 filters 
       assert.equal(attributes["session.id"], sessionId, `${name} must carry session.id`);
       assert.equal(attributes["user.id"], "user-1", `${name} must carry user.id`);
       assert.equal(attributes["langfuse.trace.name"], "pi-agent", `${name} must carry langfuse.trace.name`);
+      assert.equal(attributes["langfuse.version"], "1.5.16", `${name} must carry langfuse.version`);
       assert.deepEqual(attributes["langfuse.trace.tags"], ["pi", "cli"], `${name} must carry langfuse.trace.tags`);
       assert.equal(attributes["langfuse.trace.metadata.model"], "claude-sonnet-4", `${name} must carry trace metadata`);
       assert.equal(attributes["langfuse.trace.metadata.provider"], "anthropic", `${name} must carry trace metadata`);
@@ -1307,6 +1309,93 @@ test("child observations inherit every propagated trace attribute so v4 filters 
     }
 
     for (const observation of [tool, generation, turn, root]) observation.end();
+  } finally {
+    await forceShutdownRuntime();
+    state.config = previousConfig;
+  }
+});
+
+test("child observations inherit from their parent only, not from the ambient OTel context", async () => {
+  const previousConfig = state.config;
+  const sessionId = "01a05f0e-6ae6-714b-beb0-85eca447879a";
+
+  try {
+    ensureOtelContextManager(context, AsyncHooksContextManager);
+    state.config = {
+      publicKey: "pk_test",
+      secretKey: "sk_test",
+      host: "http://127.0.0.1:1",
+    };
+
+    const runtime = await getRuntime();
+    const attributesOf = (observation: unknown) =>
+      (observation as { otelSpan?: { attributes?: Record<string, unknown> } })?.otelSpan?.attributes ?? {};
+
+    const root: any = runtime.propagateAttributes(
+      {
+        sessionId,
+        traceName: "pi-agent",
+        version: "1.5.16",
+        tags: ["pi"],
+        metadata: { model: "claude-sonnet-4" },
+      },
+      () => runtime.startObservation("pi-agent", { input: "hi" }, { asType: "agent" } as any),
+    );
+
+    // A foreign scope is active when the child is created: another
+    // instrumentation propagating its own attributes with its own span
+    // active. `propagateAttributes` merges tags and metadata with the active
+    // context and stamps the active span, so without a clean context the
+    // child would pick up the stranger's attributes and the stranger span
+    // would be stamped with ours.
+    const stranger: any = tracing.startObservation("stranger");
+    const turn: any = tracing.propagateAttributes(
+      {
+        sessionId: "ambient-session",
+        userId: "ambient-user",
+        traceName: "ambient-trace",
+        version: "9.9.9",
+        tags: ["ambient"],
+        metadata: { model: "ambient-model", intruder: "yes" },
+      },
+      () =>
+        context.with(trace.setSpan(context.active(), stranger.otelSpan), () =>
+          root.startObservation("turn", {}, { asType: "span" }),
+        ),
+    );
+
+    const attributes = attributesOf(turn);
+    assert.equal(attributes["session.id"], sessionId);
+    assert.equal(attributes["user.id"], undefined, "user.id must not leak in from the ambient context");
+    assert.equal(attributes["langfuse.trace.name"], "pi-agent");
+    assert.equal(attributes["langfuse.version"], "1.5.16");
+    assert.deepEqual(attributes["langfuse.trace.tags"], ["pi"], "tags must not be merged with the ambient context");
+    assert.equal(attributes["langfuse.trace.metadata.model"], "claude-sonnet-4");
+    assert.equal(
+      attributes["langfuse.trace.metadata.intruder"],
+      undefined,
+      "metadata must not be merged with the ambient context",
+    );
+
+    // The explicit parent still wins over the active span.
+    assert.equal(turn.otelSpan.parentSpanContext?.spanId, root.otelSpan.spanContext().spanId);
+    assert.equal(turn.otelSpan.spanContext().traceId, root.otelSpan.spanContext().traceId);
+
+    // And the stranger span is left alone.
+    const strangerAttributes = attributesOf(stranger);
+    assert.equal(strangerAttributes["session.id"], undefined, "stranger span must not be stamped with our session");
+    assert.equal(strangerAttributes["langfuse.trace.name"], undefined);
+
+    // A child created with nothing to inherit is not stamped from the ambient context either.
+    const bare: any = runtime.startObservation("bare", {}, { asType: "agent" } as any);
+    const bareChild: any = tracing.propagateAttributes(
+      { sessionId: "ambient-session", metadata: { intruder: "yes" } },
+      () => bare.startObservation("turn", {}, { asType: "span" }),
+    );
+    assert.equal(attributesOf(bareChild)["session.id"], undefined);
+    assert.equal(attributesOf(bareChild)["langfuse.trace.metadata.intruder"], undefined);
+
+    for (const observation of [bareChild, bare, turn, stranger, root]) observation.end();
   } finally {
     await forceShutdownRuntime();
     state.config = previousConfig;


### PR DESCRIPTION
Fixes #27. Follow-up to #22.

#22 made `session.id` reach every child by re-entering the propagated OTel context in `wrapObservation.startObservation`. It re-entered with `{ sessionId }` only, so `langfuse.trace.name` and `langfuse.trace.metadata.*` still stop at the root. On Langfuse v4 every event row is filtered and aggregated on its own attributes, so generations and tools with `traceName = null` fall out of any trace-name or trace-metadata filter — and they are where cost and usage live.

## Cause

Same as #21: `propagateAttributes` seeds the context, `LangfuseSpanProcessor.onStart` stamps a span from the context active at creation, and children are created later from separate event handlers. The v4 processor sets `traceName` per event from the `langfuse.trace.name` attribute on that span and does not copy it from the root (`OtelIngestionProcessor.ts`, `traceName: spanAttributes?.[TRACE_NAME] ?? null`).

## Change

`readSessionId` becomes `readPropagatedAttributes`: it reads `session.id`, `user.id`, `langfuse.trace.name`, `langfuse.version`, `langfuse.trace.tags`, and every `langfuse.trace.metadata.*` key back off the parent span and passes the set to `propagateAttributes` for the child. Same funnel as #22 — the three `startChildObservation` call sites and the direct `parent.startObservation` in `session_compact`. Grandchildren inherit transitively, and the `state.currentSessionId` fallback for the session is unchanged. `langfuse.observation.metadata.*` (e.g. `systemPrompt`) is not in the set and does not travel down. `userId` and `version` are added to the `propagateAttributes` param type; the extension does not set them yet, but inheritance is now in place for when it does.

The re-entry runs on the OTel root context (`context.with(ROOT_CONTEXT, ...)`, exposed on the runtime as `withRootContext`). `propagateAttributes` starts from `context.active()`, merges `metadata`/`tags` with whatever that context already carries, and stamps the active span if there is one — so re-entering from the ambient context was not strictly structural: a foreign `propagateAttributes` scope or an unrelated active span at child-creation time could leak into the child, and our inherited set could be stamped onto the stranger span. With the root context, a child carries exactly what its parent carries. The parent is still explicit (`observation.startObservation` passes the parent span context), so nesting is unchanged.

## Verification

Against the installed package, building the tree exactly as the handlers do:

```
                  session.id      langfuse.trace.name   trace.metadata.model   trace.metadata.provider
                  before / after  before / after        before / after         before / after
pi-agent (root)   ✅ / ✅         ✅ / ✅               ✅ / ✅                ✅ / ✅
turn              ✅ / ✅         ❌ / ✅               ❌ / ✅                ❌ / ✅
llm-generation    ✅ / ✅         ❌ / ✅               ❌ / ✅                ❌ / ✅
bash (tool)       ✅ / ✅         ❌ / ✅               ❌ / ✅                ❌ / ✅
```

## Tests

The #22 positive case now creates the root with the full attribute set (`sessionId`, `userId`, `traceName`, `version`, `tags`, `metadata`), sets observation-level metadata on the root, and asserts every child carries the six trace attributes and none of the observation metadata. Fails on `main` (`turn must carry user.id`), passes here. A new case creates a child inside a conflicting ambient `propagateAttributes` scope with a foreign active span and asserts the child carries exactly the parent's attributes (no `user.id`, tags/metadata not merged), keeps its explicit parent and trace, and leaves the stranger span unstamped; a child with nothing to inherit is not stamped from the ambient context either. Fails without the root-context change (`user.id must not leak in from the ambient context`). The negative case from #22 (no known session → unstamped) is unchanged and still passes. `npm test` 91/91, `npm run typecheck` clean.

## Impact on existing usage

- **Dashboards counting traces by `traceName`**: observation rows matching `traceName = pi-agent` go from "roots only" to "every span". Counting traces that way over-counts from now on; the documented way is `isRootObservation = true` (Metrics v2) or `parentObservationId == null`. Cost/usage by trace name, which was `$0`, becomes correct.
- **Legacy (v3) trace path**: `hasTraceUpdates` already fires on `session.id` since #22, so every child already produces a trace-update event; this PR changes its content (name/metadata now equal to the root's), not the count. Values are identical, so the merge is idempotent.
- **Privacy**: nothing new is disclosed. The inherited metadata is the root's `captured.metadata` after `applyCapturePolicy` (`cwd` respects `captureCwd` and path hashing; source metadata only when enabled). It is replicated to more rows of the same trace in the same project.
- **Payload**: ~4–9 short string attributes per span (`cwd`, `model`, `provider`, `sessionId`, plus five source-metadata keys when enabled). A generation lands around 30 attributes, well under the OTel default of 128. Values read off the parent already passed the SDK's 200-char check, so no new SDK warnings.
- **Model switched mid-run**: children inherit the model recorded at agent start, as the root does. Previously they carried nothing; the generation's own `model` field is unaffected.
- **Ingested data**: events are immutable; this takes effect for new runs only.

